### PR TITLE
Replace FluentAssertions with Shouldly

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Four projects in `Z80Emu.sln`, all targeting **.NET 10**. Both GitHub Actions wo
 
 - **`Z80Emu.Core/`** — pure emulator library. No console / UI dependencies. This is where CPU, memory, opcode dispatch, ports, interrupts, and OS-call abstractions live.
 - **`Z80Emu/`** — console front-end ("Monitor"). Uses Spectre.Console for output and references `Z80Emu.Core`. `Program.cs` constructs `CPM22 → Emulator → Monitor` and dispatches commands.
-- **`Z80Emu.Tests/`** — NUnit + FluentAssertions tests. Tests live under folders that mirror `Z80Emu.Core` (`Processor/`, `Memory/`, `OS/`, `Utilities/`). Opcode tests are grouped by category (`ArithmeticOpcodeTests.cs`, `BitOpcodeTests.cs`, etc.).
+- **`Z80Emu.Tests/`** — NUnit + Shouldly tests. Tests live under folders that mirror `Z80Emu.Core` (`Processor/`, `Memory/`, `OS/`, `Utilities/`). Opcode tests are grouped by category (`ArithmeticOpcodeTests.cs`, `BitOpcodeTests.cs`, etc.).
 - **`ParseOpcodes/`** — code generator. Run manually to regenerate the opcode table — see the section below.
 
 ## Common commands
@@ -82,7 +82,7 @@ The generator writes to its own working directory (e.g. `ParseOpcodes/bin/...`);
 
 ## Testing patterns
 
-- NUnit with `FluentAssertions` (globally imported in `Z80Emu.Tests/Usings.cs`). Use `.Should().Be(...)`.
+- NUnit with `Shouldly` (globally imported in `Z80Emu.Tests/Usings.cs`). Use `.ShouldBe(...)`.
 - `TestHelpers.FlagsShouldBe(s, z, h, pv, n, c)` is the canonical way to assert the flag register after an opcode — use it instead of asserting individual flags so failures show the full mismatch.
 - Opcode tests typically construct a `CPU` directly, write opcode bytes into the `MMU`, call `Tick()`, then assert register/flag state. See `OpcodeTestExtensions.cs` for the shared helpers.
 - A `MockOperatingSytem` (see `EmulatorTests.cs`) implements `IDos` for tests that need to verify the OS-call dispatch path without engaging full CP/M behavior.

--- a/Z80Emu.Tests/EmulatorTests.cs
+++ b/Z80Emu.Tests/EmulatorTests.cs
@@ -42,13 +42,13 @@ public class EmulatorTests
         _emulator.OnPortChanged += (sender, args) =>
         {
             eventFired = true;
-            args.Port.Should().Be(0x01);
-            args.Value.Should().Be(0xFF);
+            args.Port.ShouldBe(0x01);
+            args.Value.ShouldBe(0xFF);
         };
 
         _emulator.Ports[0x01] = 0xFF;
 
-        eventFired.Should().BeTrue();
+        eventFired.ShouldBeTrue();
     }
 
     [Test]
@@ -58,14 +58,14 @@ public class EmulatorTests
         _emulator.OnPortChanged += (sender, args) =>
         {
             eventFired = true;
-            args.Port.Should().Be(0x01);
-            args.Value.Should().Be(0xFF);
+            args.Port.ShouldBe(0x01);
+            args.Value.ShouldBe(0xFF);
         };
 
         _emulator.Reset();
         _emulator.Ports[0x01] = 0xFF;
 
-        eventFired.Should().BeTrue();
+        eventFired.ShouldBeTrue();
     }
 
     [Test]
@@ -75,7 +75,7 @@ public class EmulatorTests
 
         _emulator.Reset();
 
-        _emulator.WarmBoot.Should().BeFalse();
+        _emulator.WarmBoot.ShouldBeFalse();
     }
 
     [Test]
@@ -85,7 +85,7 @@ public class EmulatorTests
 
         _emulator.Reset();
 
-        _emulator.Interupts.IFF1.Should().BeFalse();
+        _emulator.Interupts.IFF1.ShouldBeFalse();
     }
 
     [Test]
@@ -95,7 +95,7 @@ public class EmulatorTests
 
         _emulator.Reset();
 
-        _emulator.CPU.Registers.FlagC.Should().BeFalse();
+        _emulator.CPU.Registers.FlagC.ShouldBeFalse();
     }
 
     [Test]
@@ -105,7 +105,7 @@ public class EmulatorTests
 
         _emulator.Reset();
 
-        _emulator.CPU.Registers.A.Should().Be(0x00);
+        _emulator.CPU.Registers.A.ShouldBe(0x00);
     }
 
     [Test]
@@ -115,7 +115,7 @@ public class EmulatorTests
 
         _emulator.Reset();
 
-        _emulator.Memory[0x0100].Should().Be(0x00);
+        _emulator.Memory[0x0100].ShouldBe(0x00);
     }
 
     [Test]
@@ -125,7 +125,7 @@ public class EmulatorTests
 
         _emulator.Reset();
 
-        _emulator.Ports[0x01].Should().Be(0x00);
+        _emulator.Ports[0x01].ShouldBe(0x00);
     }
 
     [Test]
@@ -133,16 +133,16 @@ public class EmulatorTests
     {
         _emulator.LoadProgram("Test.com");
 
-        _emulator.Memory[0x0100].Should().Be(0x3A);
-        _emulator.Memory[0x0101].Should().Be(0x0B);
-        _emulator.Memory[0x0102].Should().Be(0x01);
-        _emulator.Memory[0x0103].Should().Be(0x21);
-        _emulator.Memory[0x0104].Should().Be(0x0C);
-        _emulator.Memory[0x0105].Should().Be(0x01);
+        _emulator.Memory[0x0100].ShouldBe(0x3A);
+        _emulator.Memory[0x0101].ShouldBe(0x0B);
+        _emulator.Memory[0x0102].ShouldBe(0x01);
+        _emulator.Memory[0x0103].ShouldBe(0x21);
+        _emulator.Memory[0x0104].ShouldBe(0x0C);
+        _emulator.Memory[0x0105].ShouldBe(0x01);
         // ...
-        _emulator.Memory[0x010B].Should().Be(0x38);
-        _emulator.Memory[0x010C].Should().Be(0x2B);
-        _emulator.Memory[0x010D].Should().Be(0x00);
+        _emulator.Memory[0x010B].ShouldBe(0x38);
+        _emulator.Memory[0x010C].ShouldBe(0x2B);
+        _emulator.Memory[0x010D].ShouldBe(0x00);
     }
 
     [Test]
@@ -150,16 +150,16 @@ public class EmulatorTests
     {
         _emulator.LoadProgram("Test.com", 0x0200);
 
-        _emulator.Memory[0x0200].Should().Be(0x3A);
-        _emulator.Memory[0x0201].Should().Be(0x0B);
-        _emulator.Memory[0x0202].Should().Be(0x01);
-        _emulator.Memory[0x0203].Should().Be(0x21);
-        _emulator.Memory[0x0204].Should().Be(0x0C);
-        _emulator.Memory[0x0205].Should().Be(0x01);
+        _emulator.Memory[0x0200].ShouldBe(0x3A);
+        _emulator.Memory[0x0201].ShouldBe(0x0B);
+        _emulator.Memory[0x0202].ShouldBe(0x01);
+        _emulator.Memory[0x0203].ShouldBe(0x21);
+        _emulator.Memory[0x0204].ShouldBe(0x0C);
+        _emulator.Memory[0x0205].ShouldBe(0x01);
         // ...
-        _emulator.Memory[0x020B].Should().Be(0x38);
-        _emulator.Memory[0x020C].Should().Be(0x2B);
-        _emulator.Memory[0x020D].Should().Be(0x00);
+        _emulator.Memory[0x020B].ShouldBe(0x38);
+        _emulator.Memory[0x020C].ShouldBe(0x2B);
+        _emulator.Memory[0x020D].ShouldBe(0x00);
     }
 
     [Test]
@@ -167,7 +167,7 @@ public class EmulatorTests
     {
         _emulator.LoadProgram("Test.com", 0x0200);
 
-        _emulator.CPU.Registers.PC.Should().Be(0x0200);
+        _emulator.CPU.Registers.PC.ShouldBe(0x0200);
     }
 
     [Test]
@@ -178,7 +178,7 @@ public class EmulatorTests
 
         _emulator.Reset();
 
-        _emulator.Memory[0x0200].Should().Be(0x3A);
+        _emulator.Memory[0x0200].ShouldBe(0x3A);
     }
 
     [Test]
@@ -188,8 +188,8 @@ public class EmulatorTests
 
         var op = _emulator.PeekInstruction();
 
-        op.Should().NotBeNull();
-        op.Mnemonic.Should().Be("LD A,(0x010B)");
+        op.ShouldNotBeNull();
+        op.Mnemonic.ShouldBe("LD A,(0x010B)");
     }
 
     [Test]
@@ -199,8 +199,8 @@ public class EmulatorTests
 
         var op = _emulator.Disassemble(0x0107);
 
-        op.Should().NotBeNull();
-        op.Mnemonic.Should().Be("LD (0x010D),A");
+        op.ShouldNotBeNull();
+        op.Mnemonic.ShouldBe("LD (0x010D),A");
     }
 
     [Test]
@@ -210,17 +210,17 @@ public class EmulatorTests
 
         var op = _emulator.Tick();
 
-        op.Should().NotBeNull();
-        op.Mnemonic.Should().Be("LD A,(0x010B)");
+        op.ShouldNotBeNull();
+        op.Mnemonic.ShouldBe("LD A,(0x010B)");
 
-        _emulator.CPU.Registers.A.Should().Be(0x38);
-        _emulator.CPU.Registers.PC.Should().Be(0x0103);
+        _emulator.CPU.Registers.A.ShouldBe(0x38);
+        _emulator.CPU.Registers.PC.ShouldBe(0x0103);
     }
 
     [Test]
     public void EmulatorInitizesOperatingSystem()
     {
-        _os.InitializeCalled.Should().BeTrue();
+        _os.InitializeCalled.ShouldBeTrue();
     }
 
     [Test]
@@ -228,7 +228,7 @@ public class EmulatorTests
     {
         _os.InitializeCalled = false;
         _emulator.Reset();
-        _os.InitializeCalled.Should().BeTrue();
+        _os.InitializeCalled.ShouldBeTrue();
     }
 
     [Test]
@@ -238,7 +238,7 @@ public class EmulatorTests
 
         _emulator.Tick();
 
-        _os.ExecuteCalled.Should().BeFalse();
+        _os.ExecuteCalled.ShouldBeFalse();
     }
 
     [Test]
@@ -250,6 +250,6 @@ public class EmulatorTests
 
         _emulator.Tick();
 
-        _os.ExecuteCalled.Should().BeTrue();
+        _os.ExecuteCalled.ShouldBeTrue();
     }
 }

--- a/Z80Emu.Tests/Memory/MMUTests.cs
+++ b/Z80Emu.Tests/Memory/MMUTests.cs
@@ -17,16 +17,16 @@ namespace Z80Emu.Tests.Memory
         {
             _mmu.LoadProgram("Test.com");
 
-            _mmu[0x0100].Should().Be(0x3A);
-            _mmu[0x0101].Should().Be(0x0B);
-            _mmu[0x0102].Should().Be(0x01);
-            _mmu[0x0103].Should().Be(0x21);
-            _mmu[0x0104].Should().Be(0x0C);
-            _mmu[0x0105].Should().Be(0x01);
+            _mmu[0x0100].ShouldBe(0x3A);
+            _mmu[0x0101].ShouldBe(0x0B);
+            _mmu[0x0102].ShouldBe(0x01);
+            _mmu[0x0103].ShouldBe(0x21);
+            _mmu[0x0104].ShouldBe(0x0C);
+            _mmu[0x0105].ShouldBe(0x01);
             // ...
-            _mmu[0x010B].Should().Be(0x38);
-            _mmu[0x010C].Should().Be(0x2B);
-            _mmu[0x010D].Should().Be(0x00);
+            _mmu[0x010B].ShouldBe(0x38);
+            _mmu[0x010C].ShouldBe(0x2B);
+            _mmu[0x010D].ShouldBe(0x00);
         }
 
         [Test]
@@ -34,16 +34,16 @@ namespace Z80Emu.Tests.Memory
         {
             _mmu.LoadProgram("Test.com", 0x0200);
 
-            _mmu[0x0200].Should().Be(0x3A);
-            _mmu[0x0201].Should().Be(0x0B);
-            _mmu[0x0202].Should().Be(0x01);
-            _mmu[0x0203].Should().Be(0x21);
-            _mmu[0x0204].Should().Be(0x0C);
-            _mmu[0x0205].Should().Be(0x01);
+            _mmu[0x0200].ShouldBe(0x3A);
+            _mmu[0x0201].ShouldBe(0x0B);
+            _mmu[0x0202].ShouldBe(0x01);
+            _mmu[0x0203].ShouldBe(0x21);
+            _mmu[0x0204].ShouldBe(0x0C);
+            _mmu[0x0205].ShouldBe(0x01);
             // ...
-            _mmu[0x020B].Should().Be(0x38);
-            _mmu[0x020C].Should().Be(0x2B);
-            _mmu[0x020D].Should().Be(0x00);
+            _mmu[0x020B].ShouldBe(0x38);
+            _mmu[0x020C].ShouldBe(0x2B);
+            _mmu[0x020D].ShouldBe(0x00);
         }
 
         [Test]
@@ -51,7 +51,7 @@ namespace Z80Emu.Tests.Memory
         {
             _mmu[0x0100] = 0x3A;
 
-            _mmu[0x0100].Should().Be(0x3A);
+            _mmu[0x0100].ShouldBe(0x3A);
         }
 
         [TestCase(-1)]
@@ -59,7 +59,7 @@ namespace Z80Emu.Tests.Memory
         public void ReadFromMemoryOutOfRangeThrowsException(int addr)
         {
             Action act = () => { byte b = _mmu[addr]; };
-            act.Should().Throw<IndexOutOfRangeException>();
+            Should.Throw<IndexOutOfRangeException>(act);
         }
 
         [TestCase(-1)]
@@ -67,7 +67,7 @@ namespace Z80Emu.Tests.Memory
         public void WriteToMemoryOutOfRangeThrowsException(int addr)
         {
             Action act = () => _mmu[addr] = 0x3A;
-            act.Should().Throw<IndexOutOfRangeException>();
+            Should.Throw<IndexOutOfRangeException>(act);
         }
     }
 }

--- a/Z80Emu.Tests/OS/CPM22Tests.cs
+++ b/Z80Emu.Tests/OS/CPM22Tests.cs
@@ -42,22 +42,22 @@ public class CPM22Tests
     [Test]
     public void NameIsCorrect()
     {
-        _cpm.Name.Should().Be("CP/M 2.2");
+        _cpm.Name.ShouldBe("CP/M 2.2");
     }
 
     [Test]
     public void HasCorrectCallVectors()
     {
-        _cpm.CallVectors.Should().BeEquivalentTo(new ushort[] { 0x0000, 0x0005 });
+        _cpm.CallVectors.ShouldBe(new ushort[] { 0x0000, 0x0005 }, ignoreOrder: true);
     }
 
     [Test]
     public void SetsZeroPageMemory()
     {
         // Emulator initializes CPM22
-        _emulator.Memory[0x0000].Should().Be(0xC3); // JP to warm boot
-        _emulator.Memory[0x005C].Should().Be(0x01); // FCB
-        _emulator.Memory[0x0081].Should().Be((byte)'A'); // Command tail
+        _emulator.Memory[0x0000].ShouldBe(0xC3); // JP to warm boot
+        _emulator.Memory[0x005C].ShouldBe(0x01); // FCB
+        _emulator.Memory[0x0081].ShouldBe((byte)'A'); // Command tail
     }
 
     [Test]
@@ -65,7 +65,7 @@ public class CPM22Tests
     {
         _emulator.CPU.Registers.PC = 0x0010;
         Action action = () => _cpm.Execute(_emulator);
-        action.Should().Throw<InvalidOperationException>().WithMessage("Invalid CP/M Call");
+        Should.Throw<InvalidOperationException>(action).Message.ShouldBe("Invalid CP/M Call");
     }
 
     [Test]
@@ -75,8 +75,8 @@ public class CPM22Tests
 
         _cpm.Execute(_emulator);
 
-        _emulator.WarmBoot.Should().BeTrue();
-        _emulator.CPU.Registers.PC.Should().Be(0x0302);
+        _emulator.WarmBoot.ShouldBeTrue();
+        _emulator.CPU.Registers.PC.ShouldBe(0x0302);
     }
 
     [Test]
@@ -87,8 +87,8 @@ public class CPM22Tests
 
         _cpm.Execute(_emulator);
 
-        _console.Output.ToString().Should().Be("BDOS call P_TERMCPM not implemented" + Environment.NewLine);
-        _emulator.CPU.Registers.PC.Should().Be(0x0302);
+        _console.Output.ToString().ShouldBe("BDOS call P_TERMCPM not implemented" + Environment.NewLine);
+        _emulator.CPU.Registers.PC.ShouldBe(0x0302);
     }
 
     [Test]
@@ -99,9 +99,9 @@ public class CPM22Tests
 
         _cpm.Execute(_emulator);
 
-        _emulator.CPU.Registers.A.Should().Be(0xDE);
-        _emulator.CPU.Registers.L.Should().Be(0xDE);
-        _emulator.CPU.Registers.PC.Should().Be(0x0302);
+        _emulator.CPU.Registers.A.ShouldBe(0xDE);
+        _emulator.CPU.Registers.L.ShouldBe(0xDE);
+        _emulator.CPU.Registers.PC.ShouldBe(0x0302);
     }
 
     [Test]
@@ -113,8 +113,8 @@ public class CPM22Tests
 
         _cpm.Execute(_emulator);
 
-        _console.Output.ToString().Should().Be("A");
-        _emulator.CPU.Registers.PC.Should().Be(0x0302);
+        _console.Output.ToString().ShouldBe("A");
+        _emulator.CPU.Registers.PC.ShouldBe(0x0302);
     }
 
     [Test]
@@ -133,8 +133,8 @@ public class CPM22Tests
 
         _cpm.Execute(_emulator);
 
-        _console.Output.ToString().Should().Be("Hello");
-        _emulator.CPU.Registers.PC.Should().Be(0x0302);
+        _console.Output.ToString().ShouldBe("Hello");
+        _emulator.CPU.Registers.PC.ShouldBe(0x0302);
     }
 
     [Test]
@@ -147,14 +147,14 @@ public class CPM22Tests
 
         _cpm.Execute(_emulator);
 
-        _emulator.Memory[0x0200].Should().Be(5);
-        _emulator.Memory[0x0201].Should().Be((byte)'H');
-        _emulator.Memory[0x0202].Should().Be((byte)'e');
-        _emulator.Memory[0x0203].Should().Be((byte)'l');
-        _emulator.Memory[0x0204].Should().Be((byte)'l');
-        _emulator.Memory[0x0205].Should().Be((byte)'o');
-        _emulator.Memory[0x0206].Should().Be(0x00);
-        _emulator.CPU.Registers.PC.Should().Be(0x0302);
+        _emulator.Memory[0x0200].ShouldBe(5);
+        _emulator.Memory[0x0201].ShouldBe((byte)'H');
+        _emulator.Memory[0x0202].ShouldBe((byte)'e');
+        _emulator.Memory[0x0203].ShouldBe((byte)'l');
+        _emulator.Memory[0x0204].ShouldBe((byte)'l');
+        _emulator.Memory[0x0205].ShouldBe((byte)'o');
+        _emulator.Memory[0x0206].ShouldBe(0x00);
+        _emulator.CPU.Registers.PC.ShouldBe(0x0302);
     }
 
     [Test]
@@ -167,11 +167,11 @@ public class CPM22Tests
 
         _cpm.Execute(_emulator);
 
-        _emulator.Memory[0x0200].Should().Be(3);
-        _emulator.Memory[0x0201].Should().Be((byte)'H');
-        _emulator.Memory[0x0202].Should().Be((byte)'e');
-        _emulator.Memory[0x0203].Should().Be((byte)'l');
-        _emulator.Memory[0x0204].Should().Be(0x00);
-        _emulator.CPU.Registers.PC.Should().Be(0x0302);
+        _emulator.Memory[0x0200].ShouldBe(3);
+        _emulator.Memory[0x0201].ShouldBe((byte)'H');
+        _emulator.Memory[0x0202].ShouldBe((byte)'e');
+        _emulator.Memory[0x0203].ShouldBe((byte)'l');
+        _emulator.Memory[0x0204].ShouldBe(0x00);
+        _emulator.CPU.Registers.PC.ShouldBe(0x0302);
     }
 }

--- a/Z80Emu.Tests/Processor/CpuTests.cs
+++ b/Z80Emu.Tests/Processor/CpuTests.cs
@@ -19,12 +19,12 @@ public class CpuTests
     [Test]
     public void RegistersAreInitialisedCorrectly()
     {
-        _cpu.Registers.AF.Should().Be(0x0000);
-        _cpu.Registers.BC.Should().Be(0x0000);
-        _cpu.Registers.DE.Should().Be(0x0000);
-        _cpu.Registers.HL.Should().Be(0x0000);
-        _cpu.Registers.PC.Should().Be(0x0100);
-        _cpu.Registers.SP.Should().Be(0xFFFE);
+        _cpu.Registers.AF.ShouldBe(0x0000);
+        _cpu.Registers.BC.ShouldBe(0x0000);
+        _cpu.Registers.DE.ShouldBe(0x0000);
+        _cpu.Registers.HL.ShouldBe(0x0000);
+        _cpu.Registers.PC.ShouldBe(0x0100);
+        _cpu.Registers.SP.ShouldBe(0xFFFE);
     }
 
     [Test]
@@ -39,13 +39,13 @@ public class CpuTests
 
         Opcode op = _cpu.Tick();
 
-        op.Should().NotBeNull();
-        op.Mnemonic.Should().Be("LD (0x0104),BC");
+        op.ShouldNotBeNull();
+        op.Mnemonic.ShouldBe("LD (0x0104),BC");
 
-        _cpu.Registers.PC.Should().Be(0x0104);
+        _cpu.Registers.PC.ShouldBe(0x0104);
 
-        _mmu[0x0104].Should().Be(0x0F);
-        _mmu[0x0105].Should().Be(0x2A);
+        _mmu[0x0104].ShouldBe(0x0F);
+        _mmu[0x0105].ShouldBe(0x2A);
     }
 
     [Test]
@@ -60,12 +60,12 @@ public class CpuTests
 
         Opcode op = _cpu.PeekInstruction(0x100);
 
-        op.Should().NotBeNull();
-        op.Mnemonic.Should().Be("LD (0x0104),BC");
+        op.ShouldNotBeNull();
+        op.Mnemonic.ShouldBe("LD (0x0104),BC");
 
-        _cpu.Registers.PC.Should().Be(0x0100);
+        _cpu.Registers.PC.ShouldBe(0x0100);
 
-        _mmu[0x0104].Should().Be(0x00);
+        _mmu[0x0104].ShouldBe(0x00);
     }
 
     [Test]
@@ -77,13 +77,13 @@ public class CpuTests
 
         _cpu.Return();
 
-        _cpu.Registers.PC.Should().Be(0x0302);
-        _cpu.Registers.SP.Should().Be(0xFFFE);
+        _cpu.Registers.PC.ShouldBe(0x0302);
+        _cpu.Registers.SP.ShouldBe(0xFFFE);
     }
 
     [Test]
     public void ToStringReturnsRegisters()
     {
-        _cpu.ToString().Should().Be(_cpu.Registers.ToString());
+        _cpu.ToString().ShouldBe(_cpu.Registers.ToString());
     }
 }

--- a/Z80Emu.Tests/Processor/Opcodes/ArithmeticOpcodeTests.cs
+++ b/Z80Emu.Tests/Processor/Opcodes/ArithmeticOpcodeTests.cs
@@ -40,9 +40,9 @@ public class ArithmeticOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("ADD A,(HL)");
 
-        _reg.PC.Should().Be(0x0101);
+        _reg.PC.ShouldBe(0x0101);
 
-        _reg.A.Should().Be(ex);
+        _reg.A.ShouldBe(ex);
         _reg.FlagsShouldBe(s, z, h, pv, false, c);
     }
 
@@ -69,9 +69,9 @@ public class ArithmeticOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("ADC A,(HL)");
 
-        _reg.PC.Should().Be(0x0101);
+        _reg.PC.ShouldBe(0x0101);
 
-        _reg.A.Should().Be(ex);
+        _reg.A.ShouldBe(ex);
         _reg.FlagsShouldBe(s, z, h, pv, false, c);
     }
 }

--- a/Z80Emu.Tests/Processor/Opcodes/BitOpcodeTests.cs
+++ b/Z80Emu.Tests/Processor/Opcodes/BitOpcodeTests.cs
@@ -32,8 +32,8 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction($"BIT {bit},B");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.FlagZ.Should().BeFalse();
+        _reg.PC.ShouldBe(0x0102);
+        _reg.FlagZ.ShouldBeFalse();
     }
 
     [Test]
@@ -45,8 +45,8 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction($"BIT {bit},C");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.FlagZ.Should().BeFalse();
+        _reg.PC.ShouldBe(0x0102);
+        _reg.FlagZ.ShouldBeFalse();
     }
 
     [Test]
@@ -58,8 +58,8 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction($"BIT {bit},D");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.FlagZ.Should().BeFalse();
+        _reg.PC.ShouldBe(0x0102);
+        _reg.FlagZ.ShouldBeFalse();
     }
 
     [Test]
@@ -71,8 +71,8 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction($"BIT {bit},E");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.FlagZ.Should().BeFalse();
+        _reg.PC.ShouldBe(0x0102);
+        _reg.FlagZ.ShouldBeFalse();
     }
 
     [Test]
@@ -84,8 +84,8 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction($"BIT {bit},H");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.FlagZ.Should().BeFalse();
+        _reg.PC.ShouldBe(0x0102);
+        _reg.FlagZ.ShouldBeFalse();
     }
 
     [Test]
@@ -97,8 +97,8 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction($"BIT {bit},L");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.FlagZ.Should().BeFalse();
+        _reg.PC.ShouldBe(0x0102);
+        _reg.FlagZ.ShouldBeFalse();
     }
 
     [Test]
@@ -110,8 +110,8 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction($"BIT {bit},A");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.FlagZ.Should().BeFalse();
+        _reg.PC.ShouldBe(0x0102);
+        _reg.FlagZ.ShouldBeFalse();
     }
 
     [Test]
@@ -124,8 +124,8 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction($"BIT {bit},(HL)");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.FlagZ.Should().BeFalse();
+        _reg.PC.ShouldBe(0x0102);
+        _reg.FlagZ.ShouldBeFalse();
     }
 
     [Test]
@@ -140,8 +140,8 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction($"BIT {bit},(IX+4)");
 
-        _reg.PC.Should().Be(0x0104);
-        _reg.FlagZ.Should().BeFalse();
+        _reg.PC.ShouldBe(0x0104);
+        _reg.FlagZ.ShouldBeFalse();
     }
 
     [Test]
@@ -156,8 +156,8 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction($"BIT {bit},(IY+4)");
 
-        _reg.PC.Should().Be(0x0104);
-        _reg.FlagZ.Should().BeFalse();
+        _reg.PC.ShouldBe(0x0104);
+        _reg.FlagZ.ShouldBeFalse();
     }
 
     [Test]
@@ -169,8 +169,8 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction($"RES {bit},B");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.B.Should().Be(0x00);
+        _reg.PC.ShouldBe(0x0102);
+        _reg.B.ShouldBe(0x00);
     }
 
     [Test]
@@ -182,8 +182,8 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction($"RES {bit},C");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.C.Should().Be(0x00);
+        _reg.PC.ShouldBe(0x0102);
+        _reg.C.ShouldBe(0x00);
     }
 
     [Test]
@@ -195,8 +195,8 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction($"RES {bit},D");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.D.Should().Be(0x00);
+        _reg.PC.ShouldBe(0x0102);
+        _reg.D.ShouldBe(0x00);
     }
 
     [Test]
@@ -208,8 +208,8 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction($"RES {bit},E");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.E.Should().Be(0x00);
+        _reg.PC.ShouldBe(0x0102);
+        _reg.E.ShouldBe(0x00);
     }
 
     [Test]
@@ -221,8 +221,8 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction($"RES {bit},H");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.H.Should().Be(0x00);
+        _reg.PC.ShouldBe(0x0102);
+        _reg.H.ShouldBe(0x00);
     }
 
     [Test]
@@ -234,8 +234,8 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction($"RES {bit},L");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.L.Should().Be(0x00);
+        _reg.PC.ShouldBe(0x0102);
+        _reg.L.ShouldBe(0x00);
     }
 
     [Test]
@@ -247,8 +247,8 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction($"RES {bit},A");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.A.Should().Be(0x00);
+        _reg.PC.ShouldBe(0x0102);
+        _reg.A.ShouldBe(0x00);
     }
 
     [Test]
@@ -261,8 +261,8 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction($"RES {bit},(HL)");
 
-        _reg.PC.Should().Be(0x0102);
-        _mmu[0x0200].Should().Be(0x00);
+        _reg.PC.ShouldBe(0x0102);
+        _mmu[0x0200].ShouldBe(0x00);
     }
 
     [Test]
@@ -277,8 +277,8 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction($"RES {bit},(IX+4)");
 
-        _reg.PC.Should().Be(0x0104);
-        _mmu[0x0204].Should().Be(0x00);
+        _reg.PC.ShouldBe(0x0104);
+        _mmu[0x0204].ShouldBe(0x00);
     }
 
     [Test]
@@ -293,8 +293,8 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction($"RES {bit},(IY+4)");
 
-        _reg.PC.Should().Be(0x0104);
-        _mmu[0x0204].Should().Be(0x00);
+        _reg.PC.ShouldBe(0x0104);
+        _mmu[0x0204].ShouldBe(0x00);
     }
 
     [Test]
@@ -306,8 +306,8 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction($"SET {bit},B");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.B.Should().Be((byte)(0b0000_0001 << bit));
+        _reg.PC.ShouldBe(0x0102);
+        _reg.B.ShouldBe((byte)(0b0000_0001 << bit));
     }
 
     [Test]
@@ -319,8 +319,8 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction($"SET {bit},C");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.C.Should().Be((byte)(0b0000_0001 << bit));
+        _reg.PC.ShouldBe(0x0102);
+        _reg.C.ShouldBe((byte)(0b0000_0001 << bit));
     }
 
     [Test]
@@ -332,8 +332,8 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction($"SET {bit},D");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.D.Should().Be((byte)(0b0000_0001 << bit));
+        _reg.PC.ShouldBe(0x0102);
+        _reg.D.ShouldBe((byte)(0b0000_0001 << bit));
     }
 
     [Test]
@@ -345,8 +345,8 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction($"SET {bit},E");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.E.Should().Be((byte)(0b0000_0001 << bit));
+        _reg.PC.ShouldBe(0x0102);
+        _reg.E.ShouldBe((byte)(0b0000_0001 << bit));
     }
 
     [Test]
@@ -358,8 +358,8 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction($"SET {bit},H");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.H.Should().Be((byte)(0b0000_0001 << bit));
+        _reg.PC.ShouldBe(0x0102);
+        _reg.H.ShouldBe((byte)(0b0000_0001 << bit));
     }
 
     [Test]
@@ -371,8 +371,8 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction($"SET {bit},L");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.L.Should().Be((byte)(0b0000_0001 << bit));
+        _reg.PC.ShouldBe(0x0102);
+        _reg.L.ShouldBe((byte)(0b0000_0001 << bit));
     }
 
     [Test]
@@ -384,8 +384,8 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction($"SET {bit},A");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.A.Should().Be((byte)(0b0000_0001 << bit));
+        _reg.PC.ShouldBe(0x0102);
+        _reg.A.ShouldBe((byte)(0b0000_0001 << bit));
     }
 
     [Test]
@@ -398,8 +398,8 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction($"SET {bit},(HL)");
 
-        _reg.PC.Should().Be(0x0102);
-        _mmu[0x0200].Should().Be((byte)(0b0000_0001 << bit));
+        _reg.PC.ShouldBe(0x0102);
+        _mmu[0x0200].ShouldBe((byte)(0b0000_0001 << bit));
     }
 
     [Test]
@@ -414,8 +414,8 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction($"SET {bit},(IX+4)");
 
-        _reg.PC.Should().Be(0x0104);
-        _mmu[0x0204].Should().Be((byte)(0b0000_0001 << bit));
+        _reg.PC.ShouldBe(0x0104);
+        _mmu[0x0204].ShouldBe((byte)(0b0000_0001 << bit));
     }
 
     [Test]
@@ -430,8 +430,8 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction($"SET {bit},(IY+4)");
 
-        _reg.PC.Should().Be(0x0104);
-        _mmu[0x0204].Should().Be((byte)(0b0000_0001 << bit));
+        _reg.PC.ShouldBe(0x0104);
+        _mmu[0x0204].ShouldBe((byte)(0b0000_0001 << bit));
     }
 
     [Test]
@@ -443,10 +443,10 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RLA");
 
-        _reg.PC.Should().Be(0x0101);
-        _reg.A.Should().Be(0b0000_0001);
-        _reg.FlagC.Should().BeTrue();
-        _reg.FlagZ.Should().BeFalse();
+        _reg.PC.ShouldBe(0x0101);
+        _reg.A.ShouldBe(0b0000_0001);
+        _reg.FlagC.ShouldBeTrue();
+        _reg.FlagZ.ShouldBeFalse();
     }
 
     [Test]
@@ -459,9 +459,9 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RL A");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.A.Should().Be(0b0000_0001);
-        _reg.FlagC.Should().BeTrue();
+        _reg.PC.ShouldBe(0x0102);
+        _reg.A.ShouldBe(0b0000_0001);
+        _reg.FlagC.ShouldBeTrue();
     }
 
     [Test]
@@ -474,9 +474,9 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RL B");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.B.Should().Be(0b0000_0001);
-        _reg.FlagC.Should().BeTrue();
+        _reg.PC.ShouldBe(0x0102);
+        _reg.B.ShouldBe(0b0000_0001);
+        _reg.FlagC.ShouldBeTrue();
     }
 
     [Test]
@@ -489,9 +489,9 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RL C");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.C.Should().Be(0b0000_0001);
-        _reg.FlagC.Should().BeTrue();
+        _reg.PC.ShouldBe(0x0102);
+        _reg.C.ShouldBe(0b0000_0001);
+        _reg.FlagC.ShouldBeTrue();
     }
 
     [Test]
@@ -504,9 +504,9 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RL D");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.D.Should().Be(0b0000_0001);
-        _reg.FlagC.Should().BeTrue();
+        _reg.PC.ShouldBe(0x0102);
+        _reg.D.ShouldBe(0b0000_0001);
+        _reg.FlagC.ShouldBeTrue();
     }
 
     [Test]
@@ -519,9 +519,9 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RL E");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.E.Should().Be(0b0000_0001);
-        _reg.FlagC.Should().BeTrue();
+        _reg.PC.ShouldBe(0x0102);
+        _reg.E.ShouldBe(0b0000_0001);
+        _reg.FlagC.ShouldBeTrue();
     }
 
     [Test]
@@ -534,9 +534,9 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RL H");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.H.Should().Be(0b0000_0001);
-        _reg.FlagC.Should().BeTrue();
+        _reg.PC.ShouldBe(0x0102);
+        _reg.H.ShouldBe(0b0000_0001);
+        _reg.FlagC.ShouldBeTrue();
     }
 
     [Test]
@@ -549,9 +549,9 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RL L");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.L.Should().Be(0b0000_0001);
-        _reg.FlagC.Should().BeTrue();
+        _reg.PC.ShouldBe(0x0102);
+        _reg.L.ShouldBe(0b0000_0001);
+        _reg.FlagC.ShouldBeTrue();
     }
 
     [Test]
@@ -565,9 +565,9 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RL (HL)");
 
-        _reg.PC.Should().Be(0x0102);
-        _mmu[0x0200].Should().Be(0b0000_0001);
-        _reg.FlagC.Should().BeTrue();
+        _reg.PC.ShouldBe(0x0102);
+        _mmu[0x0200].ShouldBe(0b0000_0001);
+        _reg.FlagC.ShouldBeTrue();
     }
 
     [Test]
@@ -583,9 +583,9 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RL (IX+4)");
 
-        _reg.PC.Should().Be(0x0104);
-        _mmu[0x0204].Should().Be(0b0000_0001);
-        _reg.FlagC.Should().BeTrue();
+        _reg.PC.ShouldBe(0x0104);
+        _mmu[0x0204].ShouldBe(0b0000_0001);
+        _reg.FlagC.ShouldBeTrue();
     }
 
     [Test]
@@ -601,9 +601,9 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RL (IY+4)");
 
-        _reg.PC.Should().Be(0x0104);
-        _mmu[0x0204].Should().Be(0b0000_0001);
-        _reg.FlagC.Should().BeTrue();
+        _reg.PC.ShouldBe(0x0104);
+        _mmu[0x0204].ShouldBe(0b0000_0001);
+        _reg.FlagC.ShouldBeTrue();
     }
 
     [Test]
@@ -615,10 +615,10 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RRA");
 
-        _reg.PC.Should().Be(0x0101);
-        _reg.A.Should().Be(0b1000_0000);
-        _reg.FlagC.Should().BeTrue();
-        _reg.FlagZ.Should().BeFalse();
+        _reg.PC.ShouldBe(0x0101);
+        _reg.A.ShouldBe(0b1000_0000);
+        _reg.FlagC.ShouldBeTrue();
+        _reg.FlagZ.ShouldBeFalse();
     }
 
     [Test]
@@ -631,9 +631,9 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RR A");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.A.Should().Be(0b1000_0000);
-        _reg.FlagC.Should().BeTrue();
+        _reg.PC.ShouldBe(0x0102);
+        _reg.A.ShouldBe(0b1000_0000);
+        _reg.FlagC.ShouldBeTrue();
     }
 
     [Test]
@@ -646,9 +646,9 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RR B");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.B.Should().Be(0b1000_0000);
-        _reg.FlagC.Should().BeTrue();
+        _reg.PC.ShouldBe(0x0102);
+        _reg.B.ShouldBe(0b1000_0000);
+        _reg.FlagC.ShouldBeTrue();
     }
 
     [Test]
@@ -661,9 +661,9 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RR C");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.C.Should().Be(0b1000_0000);
-        _reg.FlagC.Should().BeTrue();
+        _reg.PC.ShouldBe(0x0102);
+        _reg.C.ShouldBe(0b1000_0000);
+        _reg.FlagC.ShouldBeTrue();
     }
 
     [Test]
@@ -676,9 +676,9 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RR D");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.D.Should().Be(0b1000_0000);
-        _reg.FlagC.Should().BeTrue();
+        _reg.PC.ShouldBe(0x0102);
+        _reg.D.ShouldBe(0b1000_0000);
+        _reg.FlagC.ShouldBeTrue();
     }
 
     [Test]
@@ -691,9 +691,9 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RR E");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.E.Should().Be(0b1000_0000);
-        _reg.FlagC.Should().BeTrue();
+        _reg.PC.ShouldBe(0x0102);
+        _reg.E.ShouldBe(0b1000_0000);
+        _reg.FlagC.ShouldBeTrue();
     }
 
     [Test]
@@ -706,9 +706,9 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RR H");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.H.Should().Be(0b1000_0000);
-        _reg.FlagC.Should().BeTrue();
+        _reg.PC.ShouldBe(0x0102);
+        _reg.H.ShouldBe(0b1000_0000);
+        _reg.FlagC.ShouldBeTrue();
     }
 
     [Test]
@@ -721,9 +721,9 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RR L");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.L.Should().Be(0b1000_0000);
-        _reg.FlagC.Should().BeTrue();
+        _reg.PC.ShouldBe(0x0102);
+        _reg.L.ShouldBe(0b1000_0000);
+        _reg.FlagC.ShouldBeTrue();
     }
 
     [Test]
@@ -737,9 +737,9 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RR (HL)");
 
-        _reg.PC.Should().Be(0x0102);
-        _mmu[0x0200].Should().Be(0b1000_0000);
-        _reg.FlagC.Should().BeTrue();
+        _reg.PC.ShouldBe(0x0102);
+        _mmu[0x0200].ShouldBe(0b1000_0000);
+        _reg.FlagC.ShouldBeTrue();
     }
 
     [Test]
@@ -755,9 +755,9 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RR (IX+4)");
 
-        _reg.PC.Should().Be(0x0104);
-        _mmu[0x0204].Should().Be(0b1000_0000);
-        _reg.FlagC.Should().BeTrue();
+        _reg.PC.ShouldBe(0x0104);
+        _mmu[0x0204].ShouldBe(0b1000_0000);
+        _reg.FlagC.ShouldBeTrue();
     }
 
     [Test]
@@ -773,9 +773,9 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RR (IY+4)");
 
-        _reg.PC.Should().Be(0x0104);
-        _mmu[0x0204].Should().Be(0b1000_0000);
-        _reg.FlagC.Should().BeTrue();
+        _reg.PC.ShouldBe(0x0104);
+        _mmu[0x0204].ShouldBe(0b1000_0000);
+        _reg.FlagC.ShouldBeTrue();
     }
 
     [Test]
@@ -786,10 +786,10 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RLCA");
 
-        _reg.PC.Should().Be(0x0101);
-        _reg.A.Should().Be(0b0000_0001);
-        _reg.FlagC.Should().BeTrue();
-        _reg.FlagZ.Should().BeFalse();
+        _reg.PC.ShouldBe(0x0101);
+        _reg.A.ShouldBe(0b0000_0001);
+        _reg.FlagC.ShouldBeTrue();
+        _reg.FlagZ.ShouldBeFalse();
     }
 
     [Test]
@@ -801,9 +801,9 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RLC A");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.A.Should().Be(0b0000_0001);
-        _reg.FlagC.Should().BeTrue();
+        _reg.PC.ShouldBe(0x0102);
+        _reg.A.ShouldBe(0b0000_0001);
+        _reg.FlagC.ShouldBeTrue();
     }
 
     [Test]
@@ -815,9 +815,9 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RLC B");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.B.Should().Be(0b0000_0001);
-        _reg.FlagC.Should().BeTrue();
+        _reg.PC.ShouldBe(0x0102);
+        _reg.B.ShouldBe(0b0000_0001);
+        _reg.FlagC.ShouldBeTrue();
     }
 
     [Test]
@@ -829,9 +829,9 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RLC C");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.C.Should().Be(0b0000_0001);
-        _reg.FlagC.Should().BeTrue();
+        _reg.PC.ShouldBe(0x0102);
+        _reg.C.ShouldBe(0b0000_0001);
+        _reg.FlagC.ShouldBeTrue();
     }
 
     [Test]
@@ -843,9 +843,9 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RLC D");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.D.Should().Be(0b0000_0001);
-        _reg.FlagC.Should().BeTrue();
+        _reg.PC.ShouldBe(0x0102);
+        _reg.D.ShouldBe(0b0000_0001);
+        _reg.FlagC.ShouldBeTrue();
     }
 
     [Test]
@@ -857,9 +857,9 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RLC E");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.E.Should().Be(0b0000_0001);
-        _reg.FlagC.Should().BeTrue();
+        _reg.PC.ShouldBe(0x0102);
+        _reg.E.ShouldBe(0b0000_0001);
+        _reg.FlagC.ShouldBeTrue();
     }
 
     [Test]
@@ -871,9 +871,9 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RLC H");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.H.Should().Be(0b0000_0001);
-        _reg.FlagC.Should().BeTrue();
+        _reg.PC.ShouldBe(0x0102);
+        _reg.H.ShouldBe(0b0000_0001);
+        _reg.FlagC.ShouldBeTrue();
     }
 
     [Test]
@@ -885,9 +885,9 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RLC L");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.L.Should().Be(0b0000_0001);
-        _reg.FlagC.Should().BeTrue();
+        _reg.PC.ShouldBe(0x0102);
+        _reg.L.ShouldBe(0b0000_0001);
+        _reg.FlagC.ShouldBeTrue();
     }
 
     [Test]
@@ -900,9 +900,9 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RLC (HL)");
 
-        _reg.PC.Should().Be(0x0102);
-        _mmu[0x0200].Should().Be(0b0000_0001);
-        _reg.FlagC.Should().BeTrue();
+        _reg.PC.ShouldBe(0x0102);
+        _mmu[0x0200].ShouldBe(0b0000_0001);
+        _reg.FlagC.ShouldBeTrue();
     }
 
     [Test]
@@ -917,9 +917,9 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RLC (IX+4)");
 
-        _reg.PC.Should().Be(0x0104);
-        _mmu[0x0204].Should().Be(0b0000_0001);
-        _reg.FlagC.Should().BeTrue();
+        _reg.PC.ShouldBe(0x0104);
+        _mmu[0x0204].ShouldBe(0b0000_0001);
+        _reg.FlagC.ShouldBeTrue();
     }
 
     [Test]
@@ -934,9 +934,9 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RLC (IY+4)");
 
-        _reg.PC.Should().Be(0x0104);
-        _mmu[0x0204].Should().Be(0b0000_0001);
-        _reg.FlagC.Should().BeTrue();
+        _reg.PC.ShouldBe(0x0104);
+        _mmu[0x0204].ShouldBe(0b0000_0001);
+        _reg.FlagC.ShouldBeTrue();
     }
 
     [Test]
@@ -947,10 +947,10 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RRCA");
 
-        _reg.PC.Should().Be(0x0101);
-        _reg.A.Should().Be(0b1000_0000);
-        _reg.FlagC.Should().BeTrue();
-        _reg.FlagZ.Should().BeFalse();
+        _reg.PC.ShouldBe(0x0101);
+        _reg.A.ShouldBe(0b1000_0000);
+        _reg.FlagC.ShouldBeTrue();
+        _reg.FlagZ.ShouldBeFalse();
     }
 
     [Test]
@@ -962,9 +962,9 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RRC A");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.A.Should().Be(0b1000_0000);
-        _reg.FlagC.Should().BeTrue();
+        _reg.PC.ShouldBe(0x0102);
+        _reg.A.ShouldBe(0b1000_0000);
+        _reg.FlagC.ShouldBeTrue();
     }
 
     [Test]
@@ -976,9 +976,9 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RRC B");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.B.Should().Be(0b1000_0000);
-        _reg.FlagC.Should().BeTrue();
+        _reg.PC.ShouldBe(0x0102);
+        _reg.B.ShouldBe(0b1000_0000);
+        _reg.FlagC.ShouldBeTrue();
     }
 
     [Test]
@@ -990,9 +990,9 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RRC C");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.C.Should().Be(0b1000_0000);
-        _reg.FlagC.Should().BeTrue();
+        _reg.PC.ShouldBe(0x0102);
+        _reg.C.ShouldBe(0b1000_0000);
+        _reg.FlagC.ShouldBeTrue();
     }
 
     [Test]
@@ -1004,9 +1004,9 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RRC D");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.D.Should().Be(0b1000_0000);
-        _reg.FlagC.Should().BeTrue();
+        _reg.PC.ShouldBe(0x0102);
+        _reg.D.ShouldBe(0b1000_0000);
+        _reg.FlagC.ShouldBeTrue();
     }
 
     [Test]
@@ -1018,9 +1018,9 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RRC E");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.E.Should().Be(0b1000_0000);
-        _reg.FlagC.Should().BeTrue();
+        _reg.PC.ShouldBe(0x0102);
+        _reg.E.ShouldBe(0b1000_0000);
+        _reg.FlagC.ShouldBeTrue();
     }
 
     [Test]
@@ -1032,9 +1032,9 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RRC H");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.H.Should().Be(0b1000_0000);
-        _reg.FlagC.Should().BeTrue();
+        _reg.PC.ShouldBe(0x0102);
+        _reg.H.ShouldBe(0b1000_0000);
+        _reg.FlagC.ShouldBeTrue();
     }
 
     [Test]
@@ -1046,9 +1046,9 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RRC L");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.L.Should().Be(0b1000_0000);
-        _reg.FlagC.Should().BeTrue();
+        _reg.PC.ShouldBe(0x0102);
+        _reg.L.ShouldBe(0b1000_0000);
+        _reg.FlagC.ShouldBeTrue();
     }
 
     [Test]
@@ -1061,9 +1061,9 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RRC (HL)");
 
-        _reg.PC.Should().Be(0x0102);
-        _mmu[0x0200].Should().Be(0b1000_0000);
-        _reg.FlagC.Should().BeTrue();
+        _reg.PC.ShouldBe(0x0102);
+        _mmu[0x0200].ShouldBe(0b1000_0000);
+        _reg.FlagC.ShouldBeTrue();
     }
 
     [Test]
@@ -1078,9 +1078,9 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RRC (IX+4)");
 
-        _reg.PC.Should().Be(0x0104);
-        _mmu[0x0204].Should().Be(0b1000_0000);
-        _reg.FlagC.Should().BeTrue();
+        _reg.PC.ShouldBe(0x0104);
+        _mmu[0x0204].ShouldBe(0b1000_0000);
+        _reg.FlagC.ShouldBeTrue();
     }
 
     [Test]
@@ -1095,9 +1095,9 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RRC (IY+4)");
 
-        _reg.PC.Should().Be(0x0104);
-        _mmu[0x0204].Should().Be(0b1000_0000);
-        _reg.FlagC.Should().BeTrue();
+        _reg.PC.ShouldBe(0x0104);
+        _mmu[0x0204].ShouldBe(0b1000_0000);
+        _reg.FlagC.ShouldBeTrue();
     }
 
     // The contents of the low-order nibble of (HL) are copied to the
@@ -1116,11 +1116,11 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RRD");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.A.Should().Be(0x72);
-        _mmu[0x0200].Should().Be(0xF1);
-        _reg.FlagZ.Should().BeFalse();
-        _reg.FlagS.Should().BeFalse();
+        _reg.PC.ShouldBe(0x0102);
+        _reg.A.ShouldBe(0x72);
+        _mmu[0x0200].ShouldBe(0xF1);
+        _reg.FlagZ.ShouldBeFalse();
+        _reg.FlagS.ShouldBeFalse();
     }
 
     // The contents of the low-order nibble of (HL) are copied to the
@@ -1139,10 +1139,10 @@ public class BitOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RLD");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.A.Should().Be(0x71);
-        _mmu[0x0200].Should().Be(0x2F);
-        _reg.FlagZ.Should().BeFalse();
-        _reg.FlagS.Should().BeFalse();
+        _reg.PC.ShouldBe(0x0102);
+        _reg.A.ShouldBe(0x71);
+        _mmu[0x0200].ShouldBe(0x2F);
+        _reg.FlagZ.ShouldBeFalse();
+        _reg.FlagS.ShouldBeFalse();
     }
 }

--- a/Z80Emu.Tests/Processor/Opcodes/ControlOpcodeTests.cs
+++ b/Z80Emu.Tests/Processor/Opcodes/ControlOpcodeTests.cs
@@ -33,8 +33,8 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("CALL 0x0302");
 
-        _reg.PC.Should().Be(0x0302);
-        _reg.SP.Should().Be(0xFFFC);
+        _reg.PC.ShouldBe(0x0302);
+        _reg.SP.ShouldBe(0xFFFC);
     }
 
     [Test]
@@ -47,8 +47,8 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("CALL C,0x0302");
 
-        _reg.PC.Should().Be(0x0302);
-        _reg.SP.Should().Be(0xFFFC);
+        _reg.PC.ShouldBe(0x0302);
+        _reg.SP.ShouldBe(0xFFFC);
     }
 
     [Test]
@@ -61,8 +61,8 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("CALL C,0x0302");
 
-        _reg.PC.Should().Be(0x0103);
-        _reg.SP.Should().Be(0xFFFE);
+        _reg.PC.ShouldBe(0x0103);
+        _reg.SP.ShouldBe(0xFFFE);
     }
 
     [Test]
@@ -75,8 +75,8 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("CALL NC,0x0302");
 
-        _reg.PC.Should().Be(0x0302);
-        _reg.SP.Should().Be(0xFFFC);
+        _reg.PC.ShouldBe(0x0302);
+        _reg.SP.ShouldBe(0xFFFC);
     }
 
     [Test]
@@ -89,8 +89,8 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("CALL NC,0x0302");
 
-        _reg.PC.Should().Be(0x0103);
-        _reg.SP.Should().Be(0xFFFE);
+        _reg.PC.ShouldBe(0x0103);
+        _reg.SP.ShouldBe(0xFFFE);
     }
 
     [Test]
@@ -103,8 +103,8 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("CALL M,0x0302");
 
-        _reg.PC.Should().Be(0x0302);
-        _reg.SP.Should().Be(0xFFFC);
+        _reg.PC.ShouldBe(0x0302);
+        _reg.SP.ShouldBe(0xFFFC);
     }
 
     [Test]
@@ -117,8 +117,8 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("CALL M,0x0302");
 
-        _reg.PC.Should().Be(0x0103);
-        _reg.SP.Should().Be(0xFFFE);
+        _reg.PC.ShouldBe(0x0103);
+        _reg.SP.ShouldBe(0xFFFE);
     }
 
     [Test]
@@ -131,8 +131,8 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("CALL P,0x0302");
 
-        _reg.PC.Should().Be(0x0302);
-        _reg.SP.Should().Be(0xFFFC);
+        _reg.PC.ShouldBe(0x0302);
+        _reg.SP.ShouldBe(0xFFFC);
     }
 
     [Test]
@@ -145,8 +145,8 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("CALL P,0x0302");
 
-        _reg.PC.Should().Be(0x0103);
-        _reg.SP.Should().Be(0xFFFE);
+        _reg.PC.ShouldBe(0x0103);
+        _reg.SP.ShouldBe(0xFFFE);
     }
 
     [Test]
@@ -159,8 +159,8 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("CALL Z,0x0302");
 
-        _reg.PC.Should().Be(0x0302);
-        _reg.SP.Should().Be(0xFFFC);
+        _reg.PC.ShouldBe(0x0302);
+        _reg.SP.ShouldBe(0xFFFC);
     }
 
     [Test]
@@ -173,8 +173,8 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("CALL Z,0x0302");
 
-        _reg.PC.Should().Be(0x0103);
-        _reg.SP.Should().Be(0xFFFE);
+        _reg.PC.ShouldBe(0x0103);
+        _reg.SP.ShouldBe(0xFFFE);
     }
 
     [Test]
@@ -187,8 +187,8 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("CALL NZ,0x0302");
 
-        _reg.PC.Should().Be(0x0302);
-        _reg.SP.Should().Be(0xFFFC);
+        _reg.PC.ShouldBe(0x0302);
+        _reg.SP.ShouldBe(0xFFFC);
     }
 
     [Test]
@@ -201,8 +201,8 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("CALL NZ,0x0302");
 
-        _reg.PC.Should().Be(0x0103);
-        _reg.SP.Should().Be(0xFFFE);
+        _reg.PC.ShouldBe(0x0103);
+        _reg.SP.ShouldBe(0xFFFE);
     }
 
     [Test]
@@ -215,8 +215,8 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("CALL PE,0x0302");
 
-        _reg.PC.Should().Be(0x0302);
-        _reg.SP.Should().Be(0xFFFC);
+        _reg.PC.ShouldBe(0x0302);
+        _reg.SP.ShouldBe(0xFFFC);
     }
 
     [Test]
@@ -229,8 +229,8 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("CALL PE,0x0302");
 
-        _reg.PC.Should().Be(0x0103);
-        _reg.SP.Should().Be(0xFFFE);
+        _reg.PC.ShouldBe(0x0103);
+        _reg.SP.ShouldBe(0xFFFE);
     }
 
     [Test]
@@ -243,8 +243,8 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("CALL PO,0x0302");
 
-        _reg.PC.Should().Be(0x0302);
-        _reg.SP.Should().Be(0xFFFC);
+        _reg.PC.ShouldBe(0x0302);
+        _reg.SP.ShouldBe(0xFFFC);
     }
 
     [Test]
@@ -257,8 +257,8 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("CALL PO,0x0302");
 
-        _reg.PC.Should().Be(0x0103);
-        _reg.SP.Should().Be(0xFFFE);
+        _reg.PC.ShouldBe(0x0103);
+        _reg.SP.ShouldBe(0xFFFE);
     }
 
     [Test]
@@ -270,7 +270,7 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("JP 0x0302");
 
-        _reg.PC.Should().Be(0x0302);
+        _reg.PC.ShouldBe(0x0302);
     }
 
     [Test]
@@ -281,7 +281,7 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("JP (HL)");
 
-        _reg.PC.Should().Be(0x0110);
+        _reg.PC.ShouldBe(0x0110);
     }
 
     [Test]
@@ -293,7 +293,7 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("JP (IX)");
 
-        _reg.PC.Should().Be(0x0110);
+        _reg.PC.ShouldBe(0x0110);
     }
 
     [Test]
@@ -305,7 +305,7 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("JP (IY)");
 
-        _reg.PC.Should().Be(0x0110);
+        _reg.PC.ShouldBe(0x0110);
     }
 
     [Test]
@@ -318,7 +318,7 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("JP C,0x0302");
 
-        _reg.PC.Should().Be(0x0302);
+        _reg.PC.ShouldBe(0x0302);
     }
 
     [Test]
@@ -331,7 +331,7 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("JP C,0x0302");
 
-        _reg.PC.Should().Be(0x0103);
+        _reg.PC.ShouldBe(0x0103);
     }
 
     [Test]
@@ -344,7 +344,7 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("JP NC,0x0302");
 
-        _reg.PC.Should().Be(0x0302);
+        _reg.PC.ShouldBe(0x0302);
     }
 
     [Test]
@@ -357,7 +357,7 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("JP NC,0x0302");
 
-        _reg.PC.Should().Be(0x0103);
+        _reg.PC.ShouldBe(0x0103);
     }
 
     [Test]
@@ -370,7 +370,7 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("JP M,0x0302");
 
-        _reg.PC.Should().Be(0x0302);
+        _reg.PC.ShouldBe(0x0302);
     }
 
     [Test]
@@ -383,7 +383,7 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("JP M,0x0302");
 
-        _reg.PC.Should().Be(0x0103);
+        _reg.PC.ShouldBe(0x0103);
     }
 
     [Test]
@@ -396,7 +396,7 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("JP P,0x0302");
 
-        _reg.PC.Should().Be(0x0302);
+        _reg.PC.ShouldBe(0x0302);
     }
 
     [Test]
@@ -409,7 +409,7 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("JP P,0x0302");
 
-        _reg.PC.Should().Be(0x0103);
+        _reg.PC.ShouldBe(0x0103);
     }
 
     [Test]
@@ -422,7 +422,7 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("JP Z,0x0302");
 
-        _reg.PC.Should().Be(0x0302);
+        _reg.PC.ShouldBe(0x0302);
     }
 
     [Test]
@@ -435,7 +435,7 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("JP Z,0x0302");
 
-        _reg.PC.Should().Be(0x0103);
+        _reg.PC.ShouldBe(0x0103);
     }
 
     [Test]
@@ -448,7 +448,7 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("JP NZ,0x0302");
 
-        _reg.PC.Should().Be(0x0302);
+        _reg.PC.ShouldBe(0x0302);
     }
 
     [Test]
@@ -461,7 +461,7 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("JP NZ,0x0302");
 
-        _reg.PC.Should().Be(0x0103);
+        _reg.PC.ShouldBe(0x0103);
     }
 
     [Test]
@@ -474,7 +474,7 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("JP PE,0x0302");
 
-        _reg.PC.Should().Be(0x0302);
+        _reg.PC.ShouldBe(0x0302);
     }
 
     [Test]
@@ -487,7 +487,7 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("JP PE,0x0302");
 
-        _reg.PC.Should().Be(0x0103);
+        _reg.PC.ShouldBe(0x0103);
     }
 
     [Test]
@@ -500,7 +500,7 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("JP PO,0x0302");
 
-        _reg.PC.Should().Be(0x0302);
+        _reg.PC.ShouldBe(0x0302);
     }
 
     [Test]
@@ -513,7 +513,7 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("JP PO,0x0302");
 
-        _reg.PC.Should().Be(0x0103);
+        _reg.PC.ShouldBe(0x0103);
     }
 
     [TestCase(02, 0x104)]
@@ -526,7 +526,7 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction($"JR {relative}");
 
-        _reg.PC.Should().Be((word)expectedPC);
+        _reg.PC.ShouldBe((word)expectedPC);
     }
 
     [TestCase(02, 0x104)]
@@ -540,7 +540,7 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction($"JR C,{relative}");
 
-        _reg.PC.Should().Be((word)expectedPC);
+        _reg.PC.ShouldBe((word)expectedPC);
     }
 
     [TestCase(10)]
@@ -553,7 +553,7 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction($"JR C,{relative}");
 
-        _reg.PC.Should().Be(0x0102);
+        _reg.PC.ShouldBe(0x0102);
     }
 
     [TestCase(02, 0x104)]
@@ -567,7 +567,7 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction($"JR NC,{relative}");
 
-        _reg.PC.Should().Be((word)expectedPC);
+        _reg.PC.ShouldBe((word)expectedPC);
     }
 
     [TestCase(10)]
@@ -580,7 +580,7 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction($"JR NC,{relative}");
 
-        _reg.PC.Should().Be(0x0102);
+        _reg.PC.ShouldBe(0x0102);
     }
 
     [TestCase(02, 0x104)]
@@ -594,7 +594,7 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction($"JR Z,{relative}");
 
-        _reg.PC.Should().Be((word)expectedPC);
+        _reg.PC.ShouldBe((word)expectedPC);
     }
 
     [TestCase(10)]
@@ -607,7 +607,7 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction($"JR Z,{relative}");
 
-        _reg.PC.Should().Be(0x0102);
+        _reg.PC.ShouldBe(0x0102);
     }
 
     [TestCase(02, 0x104)]
@@ -621,7 +621,7 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction($"JR NZ,{relative}");
 
-        _reg.PC.Should().Be((word)expectedPC);
+        _reg.PC.ShouldBe((word)expectedPC);
     }
 
     [TestCase(10)]
@@ -634,7 +634,7 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction($"JR NZ,{relative}");
 
-        _reg.PC.Should().Be(0x0102);
+        _reg.PC.ShouldBe(0x0102);
     }
 
     [Test]
@@ -644,7 +644,7 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("NOP");
 
-        _reg.PC.Should().Be(0x0101);
+        _reg.PC.ShouldBe(0x0101);
     }
 
     [Test]
@@ -657,8 +657,8 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RET");
 
-        _reg.PC.Should().Be(0x0302);
-        _reg.SP.Should().Be(0xFFFE);
+        _reg.PC.ShouldBe(0x0302);
+        _reg.SP.ShouldBe(0xFFFE);
     }
 
     [Test]
@@ -672,8 +672,8 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RET C");
 
-        _reg.PC.Should().Be(0x0302);
-        _reg.SP.Should().Be(0xFFFE);
+        _reg.PC.ShouldBe(0x0302);
+        _reg.SP.ShouldBe(0xFFFE);
     }
 
     [Test]
@@ -687,8 +687,8 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RET C");
 
-        _reg.PC.Should().Be(0x0101);
-        _reg.SP.Should().Be(0xFFFC);
+        _reg.PC.ShouldBe(0x0101);
+        _reg.SP.ShouldBe(0xFFFC);
     }
 
     [Test]
@@ -702,8 +702,8 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RET NC");
 
-        _reg.PC.Should().Be(0x0302);
-        _reg.SP.Should().Be(0xFFFE);
+        _reg.PC.ShouldBe(0x0302);
+        _reg.SP.ShouldBe(0xFFFE);
     }
 
     [Test]
@@ -717,8 +717,8 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RET NC");
 
-        _reg.PC.Should().Be(0x0101);
-        _reg.SP.Should().Be(0xFFFC);
+        _reg.PC.ShouldBe(0x0101);
+        _reg.SP.ShouldBe(0xFFFC);
     }
 
     [Test]
@@ -732,8 +732,8 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RET Z");
 
-        _reg.PC.Should().Be(0x0302);
-        _reg.SP.Should().Be(0xFFFE);
+        _reg.PC.ShouldBe(0x0302);
+        _reg.SP.ShouldBe(0xFFFE);
     }
 
     [Test]
@@ -747,8 +747,8 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RET Z");
 
-        _reg.PC.Should().Be(0x0101);
-        _reg.SP.Should().Be(0xFFFC);
+        _reg.PC.ShouldBe(0x0101);
+        _reg.SP.ShouldBe(0xFFFC);
     }
 
     [Test]
@@ -762,8 +762,8 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RET NZ");
 
-        _reg.PC.Should().Be(0x0302);
-        _reg.SP.Should().Be(0xFFFE);
+        _reg.PC.ShouldBe(0x0302);
+        _reg.SP.ShouldBe(0xFFFE);
     }
 
     [Test]
@@ -777,8 +777,8 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RET NZ");
 
-        _reg.PC.Should().Be(0x0101);
-        _reg.SP.Should().Be(0xFFFC);
+        _reg.PC.ShouldBe(0x0101);
+        _reg.SP.ShouldBe(0xFFFC);
     }
 
     [Test]
@@ -792,8 +792,8 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RET M");
 
-        _reg.PC.Should().Be(0x0302);
-        _reg.SP.Should().Be(0xFFFE);
+        _reg.PC.ShouldBe(0x0302);
+        _reg.SP.ShouldBe(0xFFFE);
     }
 
     [Test]
@@ -807,8 +807,8 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RET M");
 
-        _reg.PC.Should().Be(0x0101);
-        _reg.SP.Should().Be(0xFFFC);
+        _reg.PC.ShouldBe(0x0101);
+        _reg.SP.ShouldBe(0xFFFC);
     }
 
     [Test]
@@ -822,8 +822,8 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RET P");
 
-        _reg.PC.Should().Be(0x0302);
-        _reg.SP.Should().Be(0xFFFE);
+        _reg.PC.ShouldBe(0x0302);
+        _reg.SP.ShouldBe(0xFFFE);
     }
 
     [Test]
@@ -837,8 +837,8 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RET P");
 
-        _reg.PC.Should().Be(0x0101);
-        _reg.SP.Should().Be(0xFFFC);
+        _reg.PC.ShouldBe(0x0101);
+        _reg.SP.ShouldBe(0xFFFC);
     }
 
     [Test]
@@ -852,8 +852,8 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RET PE");
 
-        _reg.PC.Should().Be(0x0302);
-        _reg.SP.Should().Be(0xFFFE);
+        _reg.PC.ShouldBe(0x0302);
+        _reg.SP.ShouldBe(0xFFFE);
     }
 
     [Test]
@@ -867,8 +867,8 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RET PE");
 
-        _reg.PC.Should().Be(0x0101);
-        _reg.SP.Should().Be(0xFFFC);
+        _reg.PC.ShouldBe(0x0101);
+        _reg.SP.ShouldBe(0xFFFC);
     }
 
     [Test]
@@ -882,8 +882,8 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RET PO");
 
-        _reg.PC.Should().Be(0x0302);
-        _reg.SP.Should().Be(0xFFFE);
+        _reg.PC.ShouldBe(0x0302);
+        _reg.SP.ShouldBe(0xFFFE);
     }
 
     [Test]
@@ -897,7 +897,7 @@ public class ControlOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RET PO");
 
-        _reg.PC.Should().Be(0x0101);
-        _reg.SP.Should().Be(0xFFFC);
+        _reg.PC.ShouldBe(0x0101);
+        _reg.SP.ShouldBe(0xFFFC);
     }
 }

--- a/Z80Emu.Tests/Processor/Opcodes/ExchangeOpcodes.cs
+++ b/Z80Emu.Tests/Processor/Opcodes/ExchangeOpcodes.cs
@@ -34,11 +34,11 @@ public class ExchangeOpcodes
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("EX (SP),HL");
 
-        _reg.PC.Should().Be(0x0101);
-        _reg.SP.Should().Be(0xFFFD);
-        _mmu[0xFFFD].Should().Be(0x21);
-        _mmu[0xFFFE].Should().Be(0xFA);
-        _reg.HL.Should().Be(0x3AE2);
+        _reg.PC.ShouldBe(0x0101);
+        _reg.SP.ShouldBe(0xFFFD);
+        _mmu[0xFFFD].ShouldBe(0x21);
+        _mmu[0xFFFE].ShouldBe(0xFA);
+        _reg.HL.ShouldBe(0x3AE2);
     }
 
     [Test]
@@ -50,11 +50,11 @@ public class ExchangeOpcodes
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("EX (SP),IX");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.SP.Should().Be(0xFFFD);
-        _mmu[0xFFFD].Should().Be(0x21);
-        _mmu[0xFFFE].Should().Be(0xFA);
-        _reg.IX.Should().Be(0x3AE2);
+        _reg.PC.ShouldBe(0x0102);
+        _reg.SP.ShouldBe(0xFFFD);
+        _mmu[0xFFFD].ShouldBe(0x21);
+        _mmu[0xFFFE].ShouldBe(0xFA);
+        _reg.IX.ShouldBe(0x3AE2);
     }
 
     [Test]
@@ -66,11 +66,11 @@ public class ExchangeOpcodes
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("EX (SP),IY");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.SP.Should().Be(0xFFFD);
-        _mmu[0xFFFD].Should().Be(0x21);
-        _mmu[0xFFFE].Should().Be(0xFA);
-        _reg.IY.Should().Be(0x3AE2);
+        _reg.PC.ShouldBe(0x0102);
+        _reg.SP.ShouldBe(0xFFFD);
+        _mmu[0xFFFD].ShouldBe(0x21);
+        _mmu[0xFFFE].ShouldBe(0xFA);
+        _reg.IY.ShouldBe(0x3AE2);
     }
 
     [Test]
@@ -82,9 +82,9 @@ public class ExchangeOpcodes
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("EX AF,AF'");
 
-        _reg.PC.Should().Be(0x0101);
-        _reg.AF.Should().Be(0x5678);
-        _reg.AF_.Should().Be(0x1234);
+        _reg.PC.ShouldBe(0x0101);
+        _reg.AF.ShouldBe(0x5678);
+        _reg.AF_.ShouldBe(0x1234);
     }
 
     [Test]
@@ -96,9 +96,9 @@ public class ExchangeOpcodes
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("EX DE,HL");
 
-        _reg.PC.Should().Be(0x0101);
-        _reg.DE.Should().Be(0x5678);
-        _reg.HL.Should().Be(0x1234);
+        _reg.PC.ShouldBe(0x0101);
+        _reg.DE.ShouldBe(0x5678);
+        _reg.HL.ShouldBe(0x1234);
     }
 
     [Test]
@@ -114,12 +114,12 @@ public class ExchangeOpcodes
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("EXX");
 
-        _reg.PC.Should().Be(0x0101);
-        _reg.BC.Should().Be(0x4321);
-        _reg.DE.Should().Be(0x8765);
-        _reg.HL.Should().Be(0xCBA9);
-        _reg.BC_.Should().Be(0x1234);
-        _reg.DE_.Should().Be(0x5678);
-        _reg.HL_.Should().Be(0x9ABC);
+        _reg.PC.ShouldBe(0x0101);
+        _reg.BC.ShouldBe(0x4321);
+        _reg.DE.ShouldBe(0x8765);
+        _reg.HL.ShouldBe(0xCBA9);
+        _reg.BC_.ShouldBe(0x1234);
+        _reg.DE_.ShouldBe(0x5678);
+        _reg.HL_.ShouldBe(0x9ABC);
     }
 }

--- a/Z80Emu.Tests/Processor/Opcodes/LoadOpcodeTests.cs
+++ b/Z80Emu.Tests/Processor/Opcodes/LoadOpcodeTests.cs
@@ -35,10 +35,10 @@ public class LoadOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("LD (0x0104),BC");
 
-        _reg.PC.Should().Be(0x0104);
+        _reg.PC.ShouldBe(0x0104);
 
-        _mmu[0x0104].Should().Be(0x0F);
-        _mmu[0x0105].Should().Be(0x2A);
+        _mmu[0x0104].ShouldBe(0x0F);
+        _mmu[0x0105].ShouldBe(0x2A);
     }
 
     [Test]
@@ -53,10 +53,10 @@ public class LoadOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("LD (0x0104),DE");
 
-        _reg.PC.Should().Be(0x0104);
+        _reg.PC.ShouldBe(0x0104);
 
-        _mmu[0x0104].Should().Be(0x0F);
-        _mmu[0x0105].Should().Be(0x2A);
+        _mmu[0x0104].ShouldBe(0x0F);
+        _mmu[0x0105].ShouldBe(0x2A);
     }
 
     [Test]
@@ -70,10 +70,10 @@ public class LoadOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("LD (0x0104),HL");
 
-        _reg.PC.Should().Be(0x0103);
+        _reg.PC.ShouldBe(0x0103);
 
-        _mmu[0x0104].Should().Be(0x0F);
-        _mmu[0x0105].Should().Be(0x2A);
+        _mmu[0x0104].ShouldBe(0x0F);
+        _mmu[0x0105].ShouldBe(0x2A);
     }
 
     [Test]
@@ -88,10 +88,10 @@ public class LoadOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("LD (0x0104),IX");
 
-        _reg.PC.Should().Be(0x0104);
+        _reg.PC.ShouldBe(0x0104);
 
-        _mmu[0x0104].Should().Be(0x0F);
-        _mmu[0x0105].Should().Be(0x2A);
+        _mmu[0x0104].ShouldBe(0x0F);
+        _mmu[0x0105].ShouldBe(0x2A);
     }
 
     [Test]
@@ -106,10 +106,10 @@ public class LoadOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("LD (0x0104),IY");
 
-        _reg.PC.Should().Be(0x0104);
+        _reg.PC.ShouldBe(0x0104);
 
-        _mmu[0x0104].Should().Be(0x0F);
-        _mmu[0x0105].Should().Be(0x2A);
+        _mmu[0x0104].ShouldBe(0x0F);
+        _mmu[0x0105].ShouldBe(0x2A);
     }
 
     [Test]
@@ -124,10 +124,10 @@ public class LoadOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("LD (0x0104),SP");
 
-        _reg.PC.Should().Be(0x0104);
+        _reg.PC.ShouldBe(0x0104);
 
-        _mmu[0x0104].Should().Be(0x0F);
-        _mmu[0x0105].Should().Be(0x2A);
+        _mmu[0x0104].ShouldBe(0x0F);
+        _mmu[0x0105].ShouldBe(0x2A);
     }
 
     [Test]
@@ -142,8 +142,8 @@ public class LoadOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("LD BC,(0x0104)");
 
-        _reg.PC.Should().Be(0x0104);
-        _reg.BC.Should().Be(0x2A0F);
+        _reg.PC.ShouldBe(0x0104);
+        _reg.BC.ShouldBe(0x2A0F);
     }
 
     [Test]
@@ -158,8 +158,8 @@ public class LoadOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("LD DE,(0x0104)");
 
-        _reg.PC.Should().Be(0x0104);
-        _reg.DE.Should().Be(0x2A0F);
+        _reg.PC.ShouldBe(0x0104);
+        _reg.DE.ShouldBe(0x2A0F);
     }
 
     [Test]
@@ -173,8 +173,8 @@ public class LoadOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("LD HL,(0x0104)");
 
-        _reg.PC.Should().Be(0x0103);
-        _reg.HL.Should().Be(0x2A0F);
+        _reg.PC.ShouldBe(0x0103);
+        _reg.HL.ShouldBe(0x2A0F);
     }
 
     [Test]
@@ -189,8 +189,8 @@ public class LoadOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("LD IX,(0x0104)");
 
-        _reg.PC.Should().Be(0x0104);
-        _reg.IX.Should().Be(0x2A0F);
+        _reg.PC.ShouldBe(0x0104);
+        _reg.IX.ShouldBe(0x2A0F);
     }
 
     [Test]
@@ -205,8 +205,8 @@ public class LoadOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("LD IY,(0x0104)");
 
-        _reg.PC.Should().Be(0x0104);
-        _reg.IY.Should().Be(0x2A0F);
+        _reg.PC.ShouldBe(0x0104);
+        _reg.IY.ShouldBe(0x2A0F);
     }
 
     [Test]
@@ -219,8 +219,8 @@ public class LoadOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("LD IX,0x2A0F");
 
-        _reg.PC.Should().Be(0x0104);
-        _reg.IX.Should().Be(0x2A0F);
+        _reg.PC.ShouldBe(0x0104);
+        _reg.IX.ShouldBe(0x2A0F);
     }
 
     [Test]
@@ -233,8 +233,8 @@ public class LoadOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("LD IY,0x2A0F");
 
-        _reg.PC.Should().Be(0x0104);
-        _reg.IY.Should().Be(0x2A0F);
+        _reg.PC.ShouldBe(0x0104);
+        _reg.IY.ShouldBe(0x2A0F);
     }
 
     [Test]
@@ -249,8 +249,8 @@ public class LoadOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("LD SP,(0x0104)");
 
-        _reg.PC.Should().Be(0x0104);
-        _reg.SP.Should().Be(0x2A0F);
+        _reg.PC.ShouldBe(0x0104);
+        _reg.SP.ShouldBe(0x2A0F);
     }
 
     [Test]
@@ -262,8 +262,8 @@ public class LoadOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("LD SP,HL");
 
-        _reg.PC.Should().Be(0x0101);
-        _reg.SP.Should().Be(0x2A0F);
+        _reg.PC.ShouldBe(0x0101);
+        _reg.SP.ShouldBe(0x2A0F);
     }
 
     [Test]
@@ -276,8 +276,8 @@ public class LoadOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("LD SP,IX");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.SP.Should().Be(0x2A0F);
+        _reg.PC.ShouldBe(0x0102);
+        _reg.SP.ShouldBe(0x2A0F);
     }
 
     [Test]
@@ -290,8 +290,8 @@ public class LoadOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("LD SP,IY");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.SP.Should().Be(0x2A0F);
+        _reg.PC.ShouldBe(0x0102);
+        _reg.SP.ShouldBe(0x2A0F);
     }
 
     [Test]
@@ -303,8 +303,8 @@ public class LoadOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("LD BC,0x2A0F");
 
-        _reg.PC.Should().Be(0x0103);
-        _reg.BC.Should().Be(0x2A0F);
+        _reg.PC.ShouldBe(0x0103);
+        _reg.BC.ShouldBe(0x2A0F);
     }
 
     [Test]
@@ -316,8 +316,8 @@ public class LoadOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("LD DE,0x2A0F");
 
-        _reg.PC.Should().Be(0x0103);
-        _reg.DE.Should().Be(0x2A0F);
+        _reg.PC.ShouldBe(0x0103);
+        _reg.DE.ShouldBe(0x2A0F);
     }
 
     [Test]
@@ -329,8 +329,8 @@ public class LoadOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("LD HL,0x2A0F");
 
-        _reg.PC.Should().Be(0x0103);
-        _reg.HL.Should().Be(0x2A0F);
+        _reg.PC.ShouldBe(0x0103);
+        _reg.HL.ShouldBe(0x2A0F);
     }
 
     [Test]
@@ -342,7 +342,7 @@ public class LoadOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("LD SP,0x2A0F");
 
-        _reg.PC.Should().Be(0x0103);
-        _reg.SP.Should().Be(0x2A0F);
+        _reg.PC.ShouldBe(0x0103);
+        _reg.SP.ShouldBe(0x2A0F);
     }
 }

--- a/Z80Emu.Tests/Processor/Opcodes/OpcodeTestExtensions.cs
+++ b/Z80Emu.Tests/Processor/Opcodes/OpcodeTestExtensions.cs
@@ -7,8 +7,8 @@ public static class OpcodeTestExtensions
     public static Opcode FetchVerifyAndExecuteInstruction(this OpcodeHandler opcodeHandler, string expectedMnemonic)
     {
         var op = opcodeHandler.FetchInstruction();
-        op.Should().NotBeNull();
-        op.Mnemonic.Should().Be(expectedMnemonic);
+        op.ShouldNotBeNull();
+        op.Mnemonic.ShouldBe(expectedMnemonic);
         op.Execute();
         return op;
     }

--- a/Z80Emu.Tests/Processor/Opcodes/PortOpcodeTests.cs
+++ b/Z80Emu.Tests/Processor/Opcodes/PortOpcodeTests.cs
@@ -52,8 +52,8 @@ public class PortOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("IN A,(0x01)");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.A.Should().Be(0x69);
+        _reg.PC.ShouldBe(0x0102);
+        _reg.A.ShouldBe(0x69);
     }
 
     [Test]
@@ -67,10 +67,10 @@ public class PortOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("IND");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.B.Should().Be(0x01);
-        _reg.HL.Should().Be(0x01FF);
-        _mmu[0x0200].Should().Be(0x69);
+        _reg.PC.ShouldBe(0x0102);
+        _reg.B.ShouldBe(0x01);
+        _reg.HL.ShouldBe(0x01FF);
+        _mmu[0x0200].ShouldBe(0x69);
     }
 
     [Test]
@@ -84,10 +84,10 @@ public class PortOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("INDR");
 
-        _reg.PC.Should().Be(0x0100);
-        _reg.B.Should().Be(0x01);
-        _reg.HL.Should().Be(0x01FF);
-        _mmu[0x0200].Should().Be(0x69);
+        _reg.PC.ShouldBe(0x0100);
+        _reg.B.ShouldBe(0x01);
+        _reg.HL.ShouldBe(0x01FF);
+        _mmu[0x0200].ShouldBe(0x69);
     }
 
     [Test]
@@ -101,10 +101,10 @@ public class PortOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("INI");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.B.Should().Be(0x01);
-        _reg.HL.Should().Be(0x0201);
-        _mmu[0x0200].Should().Be(0x69);
+        _reg.PC.ShouldBe(0x0102);
+        _reg.B.ShouldBe(0x01);
+        _reg.HL.ShouldBe(0x0201);
+        _mmu[0x0200].ShouldBe(0x69);
     }
 
     [Test]
@@ -118,10 +118,10 @@ public class PortOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("INIR");
 
-        _reg.PC.Should().Be(0x0100);
-        _reg.B.Should().Be(0x01);
-        _reg.HL.Should().Be(0x0201);
-        _mmu[0x0200].Should().Be(0x69);
+        _reg.PC.ShouldBe(0x0100);
+        _reg.B.ShouldBe(0x01);
+        _reg.HL.ShouldBe(0x0201);
+        _mmu[0x0200].ShouldBe(0x69);
     }
 
     [Test]
@@ -132,8 +132,8 @@ public class PortOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("IN A,(C)");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.A.Should().Be(0x69);
+        _reg.PC.ShouldBe(0x0102);
+        _reg.A.ShouldBe(0x69);
     }
 
     [Test]
@@ -144,8 +144,8 @@ public class PortOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("IN B,(C)");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.B.Should().Be(0x69);
+        _reg.PC.ShouldBe(0x0102);
+        _reg.B.ShouldBe(0x69);
     }
 
     [Test]
@@ -156,8 +156,8 @@ public class PortOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("IN C,(C)");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.C.Should().Be(0x69);
+        _reg.PC.ShouldBe(0x0102);
+        _reg.C.ShouldBe(0x69);
     }
 
     [Test]
@@ -168,8 +168,8 @@ public class PortOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("IN D,(C)");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.D.Should().Be(0x69);
+        _reg.PC.ShouldBe(0x0102);
+        _reg.D.ShouldBe(0x69);
     }
 
     [Test]
@@ -180,8 +180,8 @@ public class PortOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("IN E,(C)");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.E.Should().Be(0x69);
+        _reg.PC.ShouldBe(0x0102);
+        _reg.E.ShouldBe(0x69);
     }
 
     [Test]
@@ -192,8 +192,8 @@ public class PortOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("IN H,(C)");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.H.Should().Be(0x69);
+        _reg.PC.ShouldBe(0x0102);
+        _reg.H.ShouldBe(0x69);
     }
 
     [Test]
@@ -204,8 +204,8 @@ public class PortOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("IN L,(C)");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.L.Should().Be(0x69);
+        _reg.PC.ShouldBe(0x0102);
+        _reg.L.ShouldBe(0x69);
     }
 
     [TestCase(0x79, 'A', 0xAA)]
@@ -222,11 +222,11 @@ public class PortOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction($"OUT (C),{reg}");
 
-        _reg.PC.Should().Be(0x0102);
+        _reg.PC.ShouldBe(0x0102);
 
-        _ports[0xCC].Should().Be(expected);
-        _lastPort.Should().Be(0xCC);
-        _lastValue.Should().Be(expected);
+        _ports[0xCC].ShouldBe(expected);
+        _lastPort.ShouldBe(0xCC);
+        _lastValue.ShouldBe(expected);
     }
 
     [Test]
@@ -238,11 +238,11 @@ public class PortOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("OUT (0x21),A");
 
-        _reg.PC.Should().Be(0x0102);
+        _reg.PC.ShouldBe(0x0102);
 
-        _ports[0x21].Should().Be(0x69);
-        _lastPort.Should().Be(0x21);
-        _lastValue.Should().Be(0x69);
+        _ports[0x21].ShouldBe(0x69);
+        _lastPort.ShouldBe(0x21);
+        _lastValue.ShouldBe(0x69);
     }
 
     [Test]
@@ -258,12 +258,12 @@ public class PortOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("OUTD");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.B.Should().Be(0x01);
-        _reg.HL.Should().Be(0x01FF);
-        _ports[0xCC].Should().Be(0x51);
-        _lastPort.Should().Be(0xCC);
-        _lastValue.Should().Be(0x51);
+        _reg.PC.ShouldBe(0x0102);
+        _reg.B.ShouldBe(0x01);
+        _reg.HL.ShouldBe(0x01FF);
+        _ports[0xCC].ShouldBe(0x51);
+        _lastPort.ShouldBe(0xCC);
+        _lastValue.ShouldBe(0x51);
     }
 
     [Test]
@@ -279,12 +279,12 @@ public class PortOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("OTDR");
 
-        _reg.PC.Should().Be(0x0100);
-        _reg.B.Should().Be(0x01);
-        _reg.HL.Should().Be(0x01FF);
-        _ports[0xCC].Should().Be(0x51);
-        _lastPort.Should().Be(0xCC);
-        _lastValue.Should().Be(0x51);
+        _reg.PC.ShouldBe(0x0100);
+        _reg.B.ShouldBe(0x01);
+        _reg.HL.ShouldBe(0x01FF);
+        _ports[0xCC].ShouldBe(0x51);
+        _lastPort.ShouldBe(0xCC);
+        _lastValue.ShouldBe(0x51);
     }
 
     [Test]
@@ -300,12 +300,12 @@ public class PortOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("OUTI");
 
-        _reg.PC.Should().Be(0x0102);
-        _reg.B.Should().Be(0x01);
-        _reg.HL.Should().Be(0x0201);
-        _ports[0xCC].Should().Be(0x51);
-        _lastPort.Should().Be(0xCC);
-        _lastValue.Should().Be(0x51);
+        _reg.PC.ShouldBe(0x0102);
+        _reg.B.ShouldBe(0x01);
+        _reg.HL.ShouldBe(0x0201);
+        _ports[0xCC].ShouldBe(0x51);
+        _lastPort.ShouldBe(0xCC);
+        _lastValue.ShouldBe(0x51);
     }
 
     [Test]
@@ -321,11 +321,11 @@ public class PortOpcodeTests
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("OTIR");
 
-        _reg.PC.Should().Be(0x0100);
-        _reg.B.Should().Be(0x01);
-        _reg.HL.Should().Be(0x0201);
-        _ports[0xCC].Should().Be(0x51);
-        _lastPort.Should().Be(0xCC);
-        _lastValue.Should().Be(0x51);
+        _reg.PC.ShouldBe(0x0100);
+        _reg.B.ShouldBe(0x01);
+        _reg.HL.ShouldBe(0x0201);
+        _ports[0xCC].ShouldBe(0x51);
+        _lastPort.ShouldBe(0xCC);
+        _lastValue.ShouldBe(0x51);
     }
 }

--- a/Z80Emu.Tests/Processor/PortTests.cs
+++ b/Z80Emu.Tests/Processor/PortTests.cs
@@ -21,13 +21,13 @@ public class PortTests
         _ports.OnPortChanged += (sender, args) =>
         {
             eventFired = true;
-            args.Port.Should().Be(port);
-            args.Value.Should().Be(value);
+            args.Port.ShouldBe(port);
+            args.Value.ShouldBe(value);
         };
 
         _ports[port] = value;
 
-        eventFired.Should().BeTrue();
+        eventFired.ShouldBeTrue();
     }
 
     [Test]
@@ -38,6 +38,6 @@ public class PortTests
 
         _ports[port] = value;
 
-        _ports[port].Should().Be(value);
+        _ports[port].ShouldBe(value);
     }
 }

--- a/Z80Emu.Tests/Processor/RegisterTests.cs
+++ b/Z80Emu.Tests/Processor/RegisterTests.cs
@@ -16,88 +16,88 @@ public class RegisterTests
     public void ASetsHighNibbleOfAF()
     {
         _reg.A = 0xCA;
-        _reg.AF.Should().Be(0xCA00);
+        _reg.AF.ShouldBe(0xCA00);
     }
 
     [Test]
     public void FSetsLowNibbleOfAF()
     {
         _reg.F = 0xCA;
-        _reg.AF.Should().Be(0x00CA);
+        _reg.AF.ShouldBe(0x00CA);
     }
 
     [Test]
     public void AFSetsAAndF()
     {
         _reg.AF = 0xDEAD;
-        _reg.A.Should().Be(0xDE);
-        _reg.F.Should().Be(0xAD);
+        _reg.A.ShouldBe(0xDE);
+        _reg.F.ShouldBe(0xAD);
     }
 
     [Test]
     public void BSetsHighNibbleOfBC()
     {
         _reg.B = 0xCA;
-        _reg.BC.Should().Be(0xCA00);
+        _reg.BC.ShouldBe(0xCA00);
     }
 
     [Test]
     public void CSetsLowNibbleOfBC()
     {
         _reg.C = 0xCA;
-        _reg.BC.Should().Be(0x00CA);
+        _reg.BC.ShouldBe(0x00CA);
     }
 
     [Test]
     public void BCSetsBAndC()
     {
         _reg.BC = 0xDEAD;
-        _reg.B.Should().Be(0xDE);
-        _reg.C.Should().Be(0xAD);
+        _reg.B.ShouldBe(0xDE);
+        _reg.C.ShouldBe(0xAD);
     }
 
     [Test]
     public void DSetsHighNibbleOfDE()
     {
         _reg.D = 0xCA;
-        _reg.DE.Should().Be(0xCA00);
+        _reg.DE.ShouldBe(0xCA00);
     }
 
     [Test]
     public void ESetsLowNibbleOfDE()
     {
         _reg.E = 0xCA;
-        _reg.DE.Should().Be(0x00CA);
+        _reg.DE.ShouldBe(0x00CA);
     }
 
     [Test]
     public void DESetsDAndE()
     {
         _reg.DE = 0xDEAD;
-        _reg.D.Should().Be(0xDE);
-        _reg.E.Should().Be(0xAD);
+        _reg.D.ShouldBe(0xDE);
+        _reg.E.ShouldBe(0xAD);
     }
 
     [Test]
     public void HSetsHighNibbleOfHL()
     {
         _reg.H = 0xCA;
-        _reg.HL.Should().Be(0xCA00);
+        _reg.HL.ShouldBe(0xCA00);
     }
 
     [Test]
     public void LSetsLowNibbleOfHL()
     {
         _reg.L = 0xCA;
-        _reg.HL.Should().Be(0x00CA);
+        _reg.HL.ShouldBe(0x00CA);
     }
 
     [Test]
     public void HLSetsHAndL()
     {
         _reg.HL = 0xDEAD;
-        _reg.H.Should().Be(0xDE);
-        _reg.L.Should().Be(0xAD);
+        _reg.H.ShouldBe(0xDE);
+        _reg.L.ShouldBe(0xAD);
     }
 
     [Test]
@@ -105,11 +105,11 @@ public class RegisterTests
     {
         _reg.F = 0b0111_1111;
         _reg.FlagS = true;
-        _reg.FlagS.Should().Be(true);
-        _reg.F.Should().Be(0b1111_1111);
+        _reg.FlagS.ShouldBe(true);
+        _reg.F.ShouldBe(0b1111_1111);
         _reg.FlagS = false;
-        _reg.FlagS.Should().Be(false);
-        _reg.F.Should().Be(0b0111_1111);
+        _reg.FlagS.ShouldBe(false);
+        _reg.F.ShouldBe(0b0111_1111);
     }
 
     [Test]
@@ -117,11 +117,11 @@ public class RegisterTests
     {
         _reg.F = 0b1011_1111;
         _reg.FlagZ = true;
-        _reg.FlagZ.Should().Be(true);
-        _reg.F.Should().Be(0b1111_1111);
+        _reg.FlagZ.ShouldBe(true);
+        _reg.F.ShouldBe(0b1111_1111);
         _reg.FlagZ = false;
-        _reg.FlagZ.Should().Be(false);
-        _reg.F.Should().Be(0b1011_1111);
+        _reg.FlagZ.ShouldBe(false);
+        _reg.F.ShouldBe(0b1011_1111);
     }
 
     [Test]
@@ -129,11 +129,11 @@ public class RegisterTests
     {
         _reg.F = 0b1110_1111;
         _reg.FlagH = true;
-        _reg.FlagH.Should().Be(true);
-        _reg.F.Should().Be(0b1111_1111);
+        _reg.FlagH.ShouldBe(true);
+        _reg.F.ShouldBe(0b1111_1111);
         _reg.FlagH = false;
-        _reg.FlagH.Should().Be(false);
-        _reg.F.Should().Be(0b1110_1111);
+        _reg.FlagH.ShouldBe(false);
+        _reg.F.ShouldBe(0b1110_1111);
     }
 
     [Test]
@@ -141,11 +141,11 @@ public class RegisterTests
     {
         _reg.F = 0b1111_1011;
         _reg.FlagPV = true;
-        _reg.FlagPV.Should().Be(true);
-        _reg.F.Should().Be(0b1111_1111);
+        _reg.FlagPV.ShouldBe(true);
+        _reg.F.ShouldBe(0b1111_1111);
         _reg.FlagPV = false;
-        _reg.FlagPV.Should().Be(false);
-        _reg.F.Should().Be(0b1111_1011);
+        _reg.FlagPV.ShouldBe(false);
+        _reg.F.ShouldBe(0b1111_1011);
     }
 
     [Test]
@@ -153,11 +153,11 @@ public class RegisterTests
     {
         _reg.F = 0b1111_1101;
         _reg.FlagN = true;
-        _reg.FlagN.Should().Be(true);
-        _reg.F.Should().Be(0b1111_1111);
+        _reg.FlagN.ShouldBe(true);
+        _reg.F.ShouldBe(0b1111_1111);
         _reg.FlagN = false;
-        _reg.FlagN.Should().Be(false);
-        _reg.F.Should().Be(0b1111_1101);
+        _reg.FlagN.ShouldBe(false);
+        _reg.F.ShouldBe(0b1111_1101);
     }
 
     [Test]
@@ -165,112 +165,112 @@ public class RegisterTests
     {
         _reg.F = 0b1111_1110;
         _reg.FlagC = true;
-        _reg.FlagC.Should().Be(true);
-        _reg.F.Should().Be(0b1111_1111);
+        _reg.FlagC.ShouldBe(true);
+        _reg.F.ShouldBe(0b1111_1111);
         _reg.FlagC = false;
-        _reg.FlagC.Should().Be(false);
-        _reg.F.Should().Be(0b1111_1110);
+        _reg.FlagC.ShouldBe(false);
+        _reg.F.ShouldBe(0b1111_1110);
     }
 
     [Test]
     public void A_SetsHighNibbleOfAF_()
     {
         _reg.A_ = 0xCA;
-        _reg.AF_.Should().Be(0xCA00);
+        _reg.AF_.ShouldBe(0xCA00);
     }
 
     [Test]
     public void F_SetsLowNibbleOfAF_()
     {
         _reg.F_ = 0xCA;
-        _reg.AF_.Should().Be(0x00CA);
+        _reg.AF_.ShouldBe(0x00CA);
     }
 
     [Test]
     public void AF_SetsA_AndF_()
     {
         _reg.AF_ = 0xDEAD;
-        _reg.A_.Should().Be(0xDE);
-        _reg.F_.Should().Be(0xAD);
+        _reg.A_.ShouldBe(0xDE);
+        _reg.F_.ShouldBe(0xAD);
     }
 
     [Test]
     public void B_SetsHighNibbleOfBC_()
     {
         _reg.B_ = 0xCA;
-        _reg.BC_.Should().Be(0xCA00);
+        _reg.BC_.ShouldBe(0xCA00);
     }
 
     [Test]
     public void C_SetsLowNibbleOfBC_()
     {
         _reg.C_ = 0xCA;
-        _reg.BC_.Should().Be(0x00CA);
+        _reg.BC_.ShouldBe(0x00CA);
     }
 
     [Test]
     public void BC_SetsBAndC_()
     {
         _reg.BC_ = 0xDEAD;
-        _reg.B_.Should().Be(0xDE);
-        _reg.C_.Should().Be(0xAD);
+        _reg.B_.ShouldBe(0xDE);
+        _reg.C_.ShouldBe(0xAD);
     }
 
     [Test]
     public void D_SetsHighNibbleOfDE_()
     {
         _reg.D_ = 0xCA;
-        _reg.DE_.Should().Be(0xCA00);
+        _reg.DE_.ShouldBe(0xCA00);
     }
 
     [Test]
     public void E_SetsLowNibbleOfDE_()
     {
         _reg.E_ = 0xCA;
-        _reg.DE_.Should().Be(0x00CA);
+        _reg.DE_.ShouldBe(0x00CA);
     }
 
     [Test]
     public void DE_SetsDAndE_()
     {
         _reg.DE_ = 0xDEAD;
-        _reg.D_.Should().Be(0xDE);
-        _reg.E_.Should().Be(0xAD);
+        _reg.D_.ShouldBe(0xDE);
+        _reg.E_.ShouldBe(0xAD);
     }
 
     [Test]
     public void H_SetsHighNibbleOfHL_()
     {
         _reg.H_ = 0xCA;
-        _reg.HL_.Should().Be(0xCA00);
+        _reg.HL_.ShouldBe(0xCA00);
     }
 
     [Test]
     public void L_SetsLowNibbleOfHL_()
     {
         _reg.L_ = 0xCA;
-        _reg.HL_.Should().Be(0x00CA);
+        _reg.HL_.ShouldBe(0x00CA);
     }
 
     [Test]
     public void HL_SetsH_AndL_()
     {
         _reg.HL_ = 0xDEAD;
-        _reg.H_.Should().Be(0xDE);
-        _reg.L_.Should().Be(0xAD);
+        _reg.H_.ShouldBe(0xDE);
+        _reg.L_.ShouldBe(0xAD);
     }
 
     [Test]
     public void GetSetI()
     {
         _reg.I = 0xDE;
-        _reg.I.Should().Be(0xDE);
+        _reg.I.ShouldBe(0xDE);
     }
 
     [Test]
     public void GetSetR()
     {
         _reg.R = 0xDE;
-        _reg.R.Should().Be(0xDE);
+        _reg.R.ShouldBe(0xDE);
     }
 }

--- a/Z80Emu.Tests/ShouldlyByteWordExtensions.cs
+++ b/Z80Emu.Tests/ShouldlyByteWordExtensions.cs
@@ -1,0 +1,14 @@
+namespace Z80Emu.Tests;
+
+// Shouldly ships ShouldBe overloads for int/long/decimal/etc. but not for byte or ushort,
+// so byteValue.ShouldBe(0x3A) fails to resolve (the int literal pulls type inference toward
+// the int overload, which then rejects the byte/ushort receiver). These shims forward to the
+// int overload so all 8/16-bit register and memory assertions work without per-call casts.
+internal static class ShouldlyByteWordExtensions
+{
+    public static void ShouldBe(this byte actual, int expected, string customMessage = null)
+        => ((int)actual).ShouldBe(expected, customMessage);
+
+    public static void ShouldBe(this ushort actual, int expected, string customMessage = null)
+        => ((int)actual).ShouldBe(expected, customMessage);
+}

--- a/Z80Emu.Tests/TestHelpers.cs
+++ b/Z80Emu.Tests/TestHelpers.cs
@@ -6,11 +6,11 @@ public static class TestHelpers
 {
     public static void FlagsShouldBe(this Registers reg, bool s, bool z, bool h, bool pv, bool n, bool c)
     {
-        reg.FlagS.Should().Be(s);
-        reg.FlagZ.Should().Be(z);
-        reg.FlagH.Should().Be(h);
-        reg.FlagPV.Should().Be(pv);
-        reg.FlagN.Should().Be(n);
-        reg.FlagC.Should().Be(c);
+        reg.FlagS.ShouldBe(s);
+        reg.FlagZ.ShouldBe(z);
+        reg.FlagH.ShouldBe(h);
+        reg.FlagPV.ShouldBe(pv);
+        reg.FlagN.ShouldBe(n);
+        reg.FlagC.ShouldBe(c);
     }
 }

--- a/Z80Emu.Tests/Usings.cs
+++ b/Z80Emu.Tests/Usings.cs
@@ -1,5 +1,5 @@
 global using NUnit.Framework;
-global using FluentAssertions;
+global using Shouldly;
 
 // The type name only contains lower-cased ascii characters. Such names may become reserved for the language.
 #pragma warning disable CS8981

--- a/Z80Emu.Tests/Utilities/ByteExtensionTests.cs
+++ b/Z80Emu.Tests/Utilities/ByteExtensionTests.cs
@@ -17,7 +17,7 @@ public class ByteExtensionTests
     public void TestParseHexByte(string s, byte expected)
     {
         var actual = s.ParseHexByte();
-        actual.Should().Be(expected);
+        actual.ShouldBe(expected);
     }
 
     [TestCase("0x00", 0x00)]
@@ -33,8 +33,8 @@ public class ByteExtensionTests
     public void TestTryParseHexByte_Success(string s, byte expected)
     {
         var result = s.TryParseHexByte(out var actual);
-        result.Should().BeTrue();
-        actual.Should().Be(expected);
+        result.ShouldBeTrue();
+        actual.ShouldBe(expected);
     }
 
     [TestCase("-1")]
@@ -44,6 +44,6 @@ public class ByteExtensionTests
     public void TestTryParseHex_Failure(string s)
     {
         var result = s.TryParseHexByte(out var actual);
-        result.Should().BeFalse();
+        result.ShouldBeFalse();
     }
 }

--- a/Z80Emu.Tests/Utilities/TestBitUtils.cs
+++ b/Z80Emu.Tests/Utilities/TestBitUtils.cs
@@ -9,20 +9,20 @@ public class TestBitUtils
     public void TestLsb()
     {
         word b = 0xABCD;
-        b.Lsb().Should().Be(0xCD);
+        b.Lsb().ShouldBe(0xCD);
     }
 
     [Test]
     public void TestMsb()
     {
         word b = 0xABCD;
-        b.Msb().Should().Be(0xAB);
+        b.Msb().ShouldBe(0xAB);
     }
 
     [Test]
     public void TestToWord()
     {
-        BitUtils.ToWord(0xAB, 0xCD).Should().Be(0xABCD);
+        BitUtils.ToWord(0xAB, 0xCD).ShouldBe(0xABCD);
     }
 
     [TestCase(0, 0b_0000_0001, true)]
@@ -43,7 +43,7 @@ public class TestBitUtils
     [TestCase(7, 0b_0111_1111, false)]
     public void TestIsBitSet(int bit, byte b, bool expected)
     {
-        b.IsBitSet(bit).Should().Be(expected);
+        b.IsBitSet(bit).ShouldBe(expected);
     }
 
     [TestCase(0, 0b_0000_0001)]
@@ -57,7 +57,7 @@ public class TestBitUtils
     public void TestSetBit(int bit, byte expected)
     {
         byte b = 0b_0000_0000;
-        b.SetBit(bit).Should().Be(expected);
+        b.SetBit(bit).ShouldBe(expected);
     }
 
     [TestCase(0, 0b_1111_1110)]
@@ -71,7 +71,7 @@ public class TestBitUtils
     public void TestResetBit(int bit, byte expected)
     {
         byte b = 0b_1111_1111;
-        b.ResetBit(bit).Should().Be(expected);
+        b.ResetBit(bit).ShouldBe(expected);
     }
 
     [TestCase(Registers.Flag.Carry, 0b_0000_0001, true)]
@@ -88,7 +88,7 @@ public class TestBitUtils
     [TestCase(Registers.Flag.Sign, 0b_0111_1111, false)]
     public void TestGetFlag(Registers.Flag flag, byte b, bool expected)
     {
-        b.GetFlag(flag).Should().Be(expected);
+        b.GetFlag(flag).ShouldBe(expected);
     }
 
     [TestCase(Registers.Flag.Carry, 0b_0000_0001)]
@@ -100,7 +100,7 @@ public class TestBitUtils
     public void TestSetFlag(Registers.Flag flag, byte expected)
     {
         byte b = 0b_0000_0000;
-        b.SetFlag(flag).Should().Be(expected);
+        b.SetFlag(flag).ShouldBe(expected);
     }
 
     [TestCase(Registers.Flag.Carry, 0b_1111_1110)]
@@ -112,7 +112,7 @@ public class TestBitUtils
     public void TestResetFlag(Registers.Flag flag, byte expected)
     {
         byte b = 0b_1111_1111;
-        b.ResetFlag(flag).Should().Be(expected);
+        b.ResetFlag(flag).ShouldBe(expected);
     }
 
     [TestCase(Registers.Flag.Carry, 0b_0000_0001)]
@@ -124,7 +124,7 @@ public class TestBitUtils
     public void TestSetFlagTrue(Registers.Flag flag, byte expected)
     {
         byte b = 0b_0000_0000;
-        b.SetFlag(flag, true).Should().Be(expected);
+        b.SetFlag(flag, true).ShouldBe(expected);
     }
 
     [TestCase(Registers.Flag.Carry, 0b_1111_1110)]
@@ -136,7 +136,7 @@ public class TestBitUtils
     public void TestSetFlagFalse(Registers.Flag flag, byte expected)
     {
         byte b = 0b_1111_1111;
-        b.SetFlag(flag, false).Should().Be(expected);
+        b.SetFlag(flag, false).ShouldBe(expected);
     }
 
     [TestCase(0b0000_0000, true)]
@@ -151,7 +151,7 @@ public class TestBitUtils
     [TestCase(0b1111_1111, true)]
     public void TestEvenParity(byte b, bool expected)
     {
-        b.IsEvenParity().Should().Be(expected);
+        b.IsEvenParity().ShouldBe(expected);
     }
 
     [TestCase(0b0000_0000, false)]
@@ -160,7 +160,7 @@ public class TestBitUtils
     [TestCase(0b1111_1111, true)]
     public void TestIsNegative(byte b, bool expected)
     {
-        b.IsNegative().Should().Be(expected);
+        b.IsNegative().ShouldBe(expected);
     }
 
     [TestCase(0b0000_0000_0000, false)]
@@ -173,6 +173,6 @@ public class TestBitUtils
     [TestCase(0b0001_1111_1111, true)]
     public void TestIsNegative(int b, bool expected)
     {
-        b.IsNegative().Should().Be(expected);
+        b.IsNegative().ShouldBe(expected);
     }
 }

--- a/Z80Emu.Tests/Utilities/WordExtensionTests.cs
+++ b/Z80Emu.Tests/Utilities/WordExtensionTests.cs
@@ -17,7 +17,7 @@ public class WordExtensionTests
     public void TestParseHexWord(string s, int expected)
     {
         var actual = s.ParseHexWord();
-        actual.Should().Be((word)expected);
+        actual.ShouldBe((word)expected);
     }
 
     [TestCase("0x0000", 0x0000)]
@@ -33,8 +33,8 @@ public class WordExtensionTests
     public void TestTryParseHexWord_Success(string s, int expected)
     {
         var result = s.TryParseHexWord(out var actual);
-        result.Should().BeTrue();
-        actual.Should().Be((word)expected);
+        result.ShouldBeTrue();
+        actual.ShouldBe((word)expected);
     }
 
     [TestCase("-1")]
@@ -44,6 +44,6 @@ public class WordExtensionTests
     public void TestTryParseHexWord_Failure(string s)
     {
         var result = s.TryParseHexWord(out var actual);
-        result.Should().BeFalse();
+        result.ShouldBeFalse();
     }
 }

--- a/Z80Emu.Tests/Z80Emu.Tests.csproj
+++ b/Z80Emu.Tests/Z80Emu.Tests.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions.Json" Version="8.0.0" />
+    <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="NUnit" Version="4.5.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />


### PR DESCRIPTION
## Summary

- Replace FluentAssertions with Shouldly 4.3.0 (BSD-3-Clause). FA v8 (Jan 2025) re-licensed as a paid commercial product; this keeps the test suite on OSS-friendly tooling.
- Drops the only direct FA reference (`FluentAssertions.Json`, which was unused) and the entire transitive FA chain.
- Translates 654 assertion sites across 17 test files (`.Should().Be(x)` → `.ShouldBe(x)`, etc.); 1 `BeEquivalentTo` collection check → `ShouldBe(..., ignoreOrder: true)`; 3 `Throw<T>()` sites → `Should.Throw<T>(...)`.
- Adds `ShouldlyByteWordExtensions` shim: Shouldly only ships native `ShouldBe` overloads for `int`/`long`/`decimal`/etc., not `byte`/`ushort`. Two non-generic extension methods route 8/16-bit register and memory assertions to Shouldly''s `int` implementation, leaving every call site unchanged.
- Updates `CLAUDE.md` to reflect the new testing library.

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 651 passed, 0 failed
- [x] `dotnet list package --include-transitive` shows only `Shouldly 4.3.0`; no `FluentAssertions*` in the graph

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions across all test files to use Shouldly assertion library
  * Added test extension methods to support assertion patterns for byte and word types
  * Updated test project dependencies to use Shouldly framework

<!-- end of auto-generated comment: release notes by coderabbit.ai -->