### PR TITLE
Implement Z80 interrupt support and REPL int/nmi commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,17 @@ Whenever making changes to the application, increase the version number in `Z80E
 
 `Opcode.Match` linear-scans the dictionary on every fetch — there is no prefix tree / jump table. Acceptable because the table is fixed-size and the project isn't aiming for cycle accuracy. `Opcode.Bytes` contains literal hex strings plus placeholders `"n"` (immediate byte), `"d"` (signed displacement), `"nn"` (immediate word) which get resolved by `SetSubstitutions` for display and consumed by the `Execute` lambda via `NextByte`/`NextWord`.
 
+### Interrupt model
+
+Interrupts are sampled at instruction boundaries the same way real Z80 hardware does, but the servicing is implemented as a synthetic pseudo-opcode at the **start** of `Emulator.Tick()` rather than the end. When `Interupts.IsRequested` (or `IsNmiRequested`) is set and not gated, `ServiceInterrupts()` performs only the entry sequence (push PC, IFF flips, jump to vector) and returns a synthetic `Opcode { Mnemonic = "INT"|"NMI", Length = 0 }`. The next `Tick()` fetches normally at the vector. This shape is deliberate: it lets the Monitor display interrupt entry as its own line in `step` output without any new rendering code (`Step()` already prints whatever `Tick()` returned). See `docs/superpowers/specs/2026-04-27-im-interrupt-instructions-design.md` for the full design rationale.
+
+Specifics worth knowing when modifying this code:
+- **IM 0 is hardcoded as `RST 38h`** (push PC, jump to `0x0038`). Real hardware reads an opcode off the data bus; we don't emulate the bus, and `0xFF`/`RST 38h` is what most production Z80 hardware actually drove. The `RequestData` byte is ignored in IM 0.
+- **EI shadow:** `EI` sets `IFF1=IFF2=true` AND `EiPending=true`. `ServiceInterrupts` skips sampling for one tick when `EiPending` is set so that `EI; RET` lets `RET` run before any pending IRQ re-enters the ISR. NMI is also delayed by the EI shadow.
+- **NMI semantics:** copies `IFF1 → IFF2` (the save slot for `RETN`) then clears `IFF1`. NMI is not gated by `IFF1`.
+- **Latch lifecycle:** `RaiseInterrupt()`/`RaiseNmi()` set the latches. `Emulator.ServiceInterrupts` calls `Interupts.ConsumeInterrupt()`/`ConsumeNmi()` to clear them once the entry sequence completes. While `IFF1=0`, a maskable INT latch persists until `EI` re-enables sampling.
+- **Don't add direct IFF mutation outside opcode bodies and `ServiceInterrupts`.** The existing pattern is: `EI`/`DI`/`RETI`/`RETN` opcode bodies write `_int.IFF1`/`IFF2` directly. Keep it that way — `Interupts` is a state container, not a method-rich abstraction.
+
 ### Memory, ports, OS
 
 - `MMU` is a thin facade over an array of `MemoryBlock`s (currently a single 64K RAM block at `0x0000–0xFFFF`); the structure is set up to support memory-mapped regions later. Indexer-style access: `_mmu[addr]`.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Z80Emu
 
-A Z80 emulator/monitor program written in C#. Opcodes are generated automatically
-using the [JSON Opcode Table](https://github.com/deeptoaster/opcode-table/blob/master/opcode-table.json)
-from [Z80 Opcode Table](https://clrhome.org/table/).
+A Z80 emulator/monitor program written in C#. The opcode table was originally
+seeded from the [JSON Opcode Table](https://github.com/deeptoaster/opcode-table/blob/master/opcode-table.json)
+([Z80 Opcode Table](https://clrhome.org/table/)) and is now hand-maintained in
+`Z80Emu.Core/Processor/Opcodes/`.
 
 ![CI/CD Build](https://github.com/rprouse/z80emu/actions/workflows/dotnet.yml/badge.svg)
 
@@ -34,6 +35,9 @@ registers are displayed after every step or run.
 | `d [<addr>]` | `d 100` | Disassemble the program starting at the given address. If no address is given, will start disassembly at the program counter. If entered again, it will continue after the last disassembled address. |
 | `p <port>` | `p 0x42` | View the value in the given port. The port must be a hex number. |
 | `p <port> <byte>` | `p 0x42 0x0a` | Set the given byte into the given port. The port and byte must be a hex number. |
+| `int` | `int` | Latch a maskable interrupt request (uses current `IM` mode and `I` register) |
+| `int <byte>` | `int 04` | Latch a maskable interrupt with a bus byte. Used as the IM 2 vector low byte; ignored in IM 0 / IM 1 |
+| `nmi` | `nmi` | Latch a non-maskable interrupt request |
 | `b` | `b` | Manage breakpoints |
 | `q`     | `q`     | Quit the emulator |
 

--- a/Z80Emu.Core/Emulator.cs
+++ b/Z80Emu.Core/Emulator.cs
@@ -58,6 +58,10 @@ public class Emulator
 
     public Opcode Tick()
     {
+        Opcode? interruptOpcode = ServiceInterrupts();
+        if (interruptOpcode != null)
+            return interruptOpcode;
+
         Opcode opcode = CPU.Tick();
 
         // If we are using an OS, check if we need to make a system call
@@ -65,6 +69,27 @@ public class Emulator
             OperatingSystem.Execute(this);
 
         return opcode;
+    }
+
+    private Opcode? ServiceInterrupts()
+    {
+        if (Interupts.EiPending)
+        {
+            // EI shadow expires — skip sampling for this tick.
+            Interupts.EiPending = false;
+            return null;
+        }
+
+        if (Interupts.IsNmiRequested)
+        {
+            CPU.AcceptInterrupt(0x0066);
+            Interupts.IFF2 = Interupts.IFF1;
+            Interupts.IFF1 = false;
+            Interupts.ConsumeNmi();
+            return new Opcode("NMI", new string[0], "0", "Non-maskable interrupt accepted -> 0x0066");
+        }
+
+        return null;
     }
 
     public Opcode PeekInstruction() => CPU.PeekInstruction(CPU.Registers.PC);

--- a/Z80Emu.Core/Emulator.cs
+++ b/Z80Emu.Core/Emulator.cs
@@ -2,6 +2,7 @@ using Z80Emu.Core.Memory;
 using Z80Emu.Core.OS;
 using Z80Emu.Core.Processor;
 using Z80Emu.Core.Processor.Opcodes;
+using Z80Emu.Core.Utilities;
 
 namespace Z80Emu.Core;
 
@@ -91,15 +92,28 @@ public class Emulator
 
         if (Interupts.IsRequested && Interupts.IFF1)
         {
-            // IM 0 is hardcoded as RST 38h; IM 1 also jumps to 0x0038.
-            // IM 2 lookup is added in a later task.
-            word vector = 0x0038;
-            string desc = Interupts.Mode switch
+            word vector;
+            string desc;
+            switch (Interupts.Mode)
             {
-                InterruptMode.Mode0 => "Maskable interrupt accepted (IM 0) -> 0x0038 (RST 38h)",
-                InterruptMode.Mode1 => "Maskable interrupt accepted (IM 1) -> 0x0038",
-                _                   => "Maskable interrupt accepted -> 0x0038",
-            };
+                case InterruptMode.Mode2:
+                    {
+                        word vectorPtr = (word)((CPU.Registers.I << 8) | (Interupts.RequestData ?? 0xFF));
+                        byte lo = Memory[vectorPtr];
+                        byte hi = Memory[(word)(vectorPtr + 1)];
+                        vector = BitUtils.ToWord(hi, lo);
+                        desc = $"Maskable interrupt accepted (IM 2) -> 0x{vector:X4}";
+                        break;
+                    }
+                case InterruptMode.Mode1:
+                    vector = 0x0038;
+                    desc = "Maskable interrupt accepted (IM 1) -> 0x0038";
+                    break;
+                default: // Mode0
+                    vector = 0x0038;
+                    desc = "Maskable interrupt accepted (IM 0) -> 0x0038 (RST 38h)";
+                    break;
+            }
             CPU.AcceptInterrupt(vector);
             Interupts.IFF1 = false;
             Interupts.IFF2 = false;

--- a/Z80Emu.Core/Emulator.cs
+++ b/Z80Emu.Core/Emulator.cs
@@ -102,16 +102,16 @@ public class Emulator
                         byte lo = Memory[vectorPtr];
                         byte hi = Memory[(word)(vectorPtr + 1)];
                         vector = BitUtils.ToWord(hi, lo);
-                        desc = $"Maskable interrupt accepted (IM 2) -> 0x{vector:X4}";
+                        desc = $"Maskable interrupt accepted (IM 2) → 0x{vector:X4}";
                         break;
                     }
                 case InterruptMode.Mode1:
                     vector = 0x0038;
-                    desc = "Maskable interrupt accepted (IM 1) -> 0x0038";
+                    desc = "Maskable interrupt accepted (IM 1) → 0x0038";
                     break;
                 default: // Mode0
                     vector = 0x0038;
-                    desc = "Maskable interrupt accepted (IM 0) -> 0x0038 (RST 38h)";
+                    desc = "Maskable interrupt accepted (IM 0) → 0x0038 (RST 38h)";
                     break;
             }
             CPU.AcceptInterrupt(vector);

--- a/Z80Emu.Core/Emulator.cs
+++ b/Z80Emu.Core/Emulator.cs
@@ -46,7 +46,7 @@ public class Emulator
     {
         WarmBoot = false;
         Memory = new MMU();
-        Interupts = new Interupts(Memory);
+        Interupts = new Interupts();
         Ports = new Ports();
         Ports.OnPortChanged += (sender, args) => OnPortChanged?.Invoke(sender, args);
         CPU = new CPU(Interupts, Memory, Ports);
@@ -87,7 +87,7 @@ public class Emulator
             Interupts.IFF2 = Interupts.IFF1;
             Interupts.IFF1 = false;
             Interupts.ConsumeNmi();
-            return new Opcode("NMI", new string[0], "0", "Non-maskable interrupt accepted -> 0x0066");
+            return new Opcode("NMI", new string[0], "0", "Non-maskable interrupt accepted → 0x0066");
         }
 
         if (Interupts.IsRequested && Interupts.IFF1)

--- a/Z80Emu.Core/Emulator.cs
+++ b/Z80Emu.Core/Emulator.cs
@@ -89,6 +89,24 @@ public class Emulator
             return new Opcode("NMI", new string[0], "0", "Non-maskable interrupt accepted -> 0x0066");
         }
 
+        if (Interupts.IsRequested && Interupts.IFF1)
+        {
+            // IM 0 is hardcoded as RST 38h; IM 1 also jumps to 0x0038.
+            // IM 2 lookup is added in a later task.
+            word vector = 0x0038;
+            string desc = Interupts.Mode switch
+            {
+                InterruptMode.Mode0 => "Maskable interrupt accepted (IM 0) -> 0x0038 (RST 38h)",
+                InterruptMode.Mode1 => "Maskable interrupt accepted (IM 1) -> 0x0038",
+                _                   => "Maskable interrupt accepted -> 0x0038",
+            };
+            CPU.AcceptInterrupt(vector);
+            Interupts.IFF1 = false;
+            Interupts.IFF2 = false;
+            Interupts.ConsumeInterrupt();
+            return new Opcode("INT", new string[0], "0", desc);
+        }
+
         return null;
     }
 

--- a/Z80Emu.Core/Processor/CPU.cs
+++ b/Z80Emu.Core/Processor/CPU.cs
@@ -50,6 +50,12 @@ public class CPU
     /// </summary>
     public void Return() => _opcodeHandler.RET();
 
-    public override string ToString() => 
+    /// <summary>
+    /// Push PC onto the stack and jump to the given vector. Used by
+    /// Emulator.ServiceInterrupts for INT and NMI entry.
+    /// </summary>
+    public void AcceptInterrupt(word vector) => _opcodeHandler.RST(vector);
+
+    public override string ToString() =>
         _reg.ToString();
 }

--- a/Z80Emu.Core/Processor/InterruptMode.cs
+++ b/Z80Emu.Core/Processor/InterruptMode.cs
@@ -1,0 +1,8 @@
+namespace Z80Emu.Core.Processor;
+
+public enum InterruptMode
+{
+    Mode0,
+    Mode1,
+    Mode2,
+}

--- a/Z80Emu.Core/Processor/Interupts.cs
+++ b/Z80Emu.Core/Processor/Interupts.cs
@@ -28,20 +28,6 @@ public class Interupts
     }
 
     /// <summary>
-    /// Disable Interrupts
-    /// </summary>
-    public void Disable()
-    {
-    }
-
-    /// <summary>
-    /// Enable Interrupts
-    /// </summary>
-    public void Enable()
-    {
-    }
-
-    /// <summary>
     /// Latch a maskable interrupt request. The optional data byte is used
     /// as the IM 2 vector low byte; ignored in IM 0 / IM 1.
     /// </summary>

--- a/Z80Emu.Core/Processor/Interupts.cs
+++ b/Z80Emu.Core/Processor/Interupts.cs
@@ -9,6 +9,19 @@ public class Interupts
     public bool IFF1 { get; set; }
     public bool IFF2 { get; set; }
 
+    public InterruptMode Mode { get; set; }
+
+    /// <summary>
+    /// True after EI for one tick — interrupt sampling is suppressed for that
+    /// tick so an EI immediately followed by RET runs the RET before any
+    /// pending IRQ re-enters the ISR.
+    /// </summary>
+    public bool EiPending { get; set; }
+
+    public bool IsRequested { get; private set; }
+    public byte? RequestData { get; private set; }
+    public bool IsNmiRequested { get; private set; }
+
     public Interupts(MMU mmu)
     {
         _mmu = mmu;
@@ -26,5 +39,40 @@ public class Interupts
     /// </summary>
     public void Enable()
     {
+    }
+
+    /// <summary>
+    /// Latch a maskable interrupt request. The optional data byte is used
+    /// as the IM 2 vector low byte; ignored in IM 0 / IM 1.
+    /// </summary>
+    public void RaiseInterrupt(byte? data = null)
+    {
+        IsRequested = true;
+        RequestData = data;
+    }
+
+    /// <summary>
+    /// Latch a non-maskable interrupt request.
+    /// </summary>
+    public void RaiseNmi()
+    {
+        IsNmiRequested = true;
+    }
+
+    /// <summary>
+    /// Called by Emulator.ServiceInterrupts after a maskable INT is taken.
+    /// </summary>
+    public void ConsumeInterrupt()
+    {
+        IsRequested = false;
+        RequestData = null;
+    }
+
+    /// <summary>
+    /// Called by Emulator.ServiceInterrupts after an NMI is taken.
+    /// </summary>
+    public void ConsumeNmi()
+    {
+        IsNmiRequested = false;
     }
 }

--- a/Z80Emu.Core/Processor/Interupts.cs
+++ b/Z80Emu.Core/Processor/Interupts.cs
@@ -1,11 +1,7 @@
-using Z80Emu.Core.Memory;
-
 namespace Z80Emu.Core.Processor;
 
 public class Interupts
 {
-    private readonly MMU _mmu;
-
     public bool IFF1 { get; set; }
     public bool IFF2 { get; set; }
 
@@ -21,11 +17,6 @@ public class Interupts
     public bool IsRequested { get; private set; }
     public byte? RequestData { get; private set; }
     public bool IsNmiRequested { get; private set; }
-
-    public Interupts(MMU mmu)
-    {
-        _mmu = mmu;
-    }
 
     /// <summary>
     /// Latch a maskable interrupt request. The optional data byte is used

--- a/Z80Emu.Core/Processor/Opcodes/OpcodeHandler.Methods.cs
+++ b/Z80Emu.Core/Processor/Opcodes/OpcodeHandler.Methods.cs
@@ -319,9 +319,9 @@ public partial class OpcodeHandler
             _reg.HL_ = temp;
         };
         _opcodes["76 HALT"].Execute = () => _reg.PC--;
-        _opcodes["ED IM 0"].Execute = () => { };
-        _opcodes["ED IM 1"].Execute = () => { };
-        _opcodes["ED IM 2"].Execute = () => { };
+        _opcodes["ED IM 0"].Execute = () => _int.Mode = InterruptMode.Mode0;
+        _opcodes["ED IM 1"].Execute = () => _int.Mode = InterruptMode.Mode1;
+        _opcodes["ED IM 2"].Execute = () => _int.Mode = InterruptMode.Mode2;
         _opcodes["DB IN A,(n)"].Execute = () => _reg.A = _ports[NextByte()];
         _opcodes["ED IN B,(C)"].Execute = () => _reg.B = _ports[_reg.C];
         _opcodes["ED IN C,(C)"].Execute = () => _reg.C = _ports[_reg.C];

--- a/Z80Emu.Core/Processor/Opcodes/OpcodeHandler.Methods.cs
+++ b/Z80Emu.Core/Processor/Opcodes/OpcodeHandler.Methods.cs
@@ -1,4 +1,3 @@
-using Z80Emu.Core.Memory;
 using Z80Emu.Core.Utilities;
 
 namespace Z80Emu.Core.Processor.Opcodes;

--- a/Z80Emu.Core/Processor/Opcodes/OpcodeHandler.Methods.cs
+++ b/Z80Emu.Core/Processor/Opcodes/OpcodeHandler.Methods.cs
@@ -258,7 +258,12 @@ public partial class OpcodeHandler
         _opcodes["25 DEC H"].Execute = () => _reg.H = DEC(_reg.H);
         _opcodes["2D DEC L"].Execute = () => _reg.L = DEC(_reg.L);
         _opcodes["3D DEC A"].Execute = () => _reg.A = DEC(_reg.A);
-        _opcodes["F3 DI"].Execute = () => _int.Disable();
+        _opcodes["F3 DI"].Execute = () =>
+        {
+            _int.IFF1 = false;
+            _int.IFF2 = false;
+            _int.EiPending = false;
+        };
         _opcodes["10 DJNZ d"].Execute = () =>
         {
             _operand = NextByte();
@@ -266,7 +271,12 @@ public partial class OpcodeHandler
             if (_reg.B == 0) return;
             _reg.PC = (word)(_reg.PC + (sbyte)_operand);
         };
-        _opcodes["FB EI"].Execute = () => _int.Enable();
+        _opcodes["FB EI"].Execute = () =>
+        {
+            _int.IFF1 = true;
+            _int.IFF2 = true;
+            _int.EiPending = true;
+        };
         _opcodes["E3 EX (SP),HL"].Execute = () =>
         {
             _address = _reg.SP;

--- a/Z80Emu.Core/Processor/Opcodes/OpcodeHandler.cs
+++ b/Z80Emu.Core/Processor/Opcodes/OpcodeHandler.cs
@@ -506,13 +506,13 @@ public partial class OpcodeHandler
         _reg.FlagN = false;
     }
 
-    Action RST(word address) =>
-        () =>
-        {
-            _mmu[--_reg.SP] = _reg.PC.Msb();
-            _mmu[--_reg.SP] = _reg.PC.Lsb();
-            _reg.PC = address;
-        };
+    // This is public so interrupt entry can push PC and jump to a vector.
+    public void RST(word address)
+    {
+        _mmu[--_reg.SP] = _reg.PC.Msb();
+        _mmu[--_reg.SP] = _reg.PC.Lsb();
+        _reg.PC = address;
+    }
 
     void SBC(byte value)
     {

--- a/Z80Emu.Tests/Processor/CpuTests.cs
+++ b/Z80Emu.Tests/Processor/CpuTests.cs
@@ -13,7 +13,7 @@ public class CpuTests
     public void Setup()
     {
         _mmu = new MMU();
-        _cpu = new CPU(new Interupts(_mmu), _mmu, new Ports());
+        _cpu = new CPU(new Interupts(), _mmu, new Ports());
     }
 
     [Test]

--- a/Z80Emu.Tests/Processor/InteruptsTests.cs
+++ b/Z80Emu.Tests/Processor/InteruptsTests.cs
@@ -1,0 +1,52 @@
+using Z80Emu.Core;
+using Z80Emu.Core.Processor;
+using Z80Emu.Core.Utilities;
+using Z80Emu.Tests;  // MockOperatingSytem lives in the parent namespace
+
+namespace Z80Emu.Tests.Processor;
+
+public class InteruptsTests
+{
+    Emulator _emulator;
+
+    [SetUp]
+    public void Setup()
+    {
+        _emulator = new Emulator(new MockOperatingSytem());
+        // Put a NOP at PC so any normal Tick advances by one and stays in range.
+        _emulator.Memory[0x0100] = 0x00;
+        _emulator.Memory[0x0101] = 0x00;
+        _emulator.Memory[0x0102] = 0x00;
+    }
+
+    [Test]
+    public void Nmi_PushesPC_JumpsTo0x0066_ClearsLatch()
+    {
+        word originalPC = _emulator.CPU.Registers.PC;
+        word originalSP = _emulator.CPU.Registers.SP;
+
+        _emulator.Interupts.RaiseNmi();
+        var op = _emulator.Tick();
+
+        op.Mnemonic.ShouldBe("NMI");
+        _emulator.CPU.Registers.PC.ShouldBe((word)0x0066);
+        _emulator.CPU.Registers.SP.ShouldBe((word)(originalSP - 2));
+        _emulator.Memory[(word)(originalSP - 2)].ShouldBe(originalPC.Lsb());
+        _emulator.Memory[(word)(originalSP - 1)].ShouldBe(originalPC.Msb());
+        _emulator.Interupts.IsNmiRequested.ShouldBeFalse();
+    }
+
+    [Test]
+    public void Nmi_CopiesIFF1_ToIFF2_AndClearsIFF1()
+    {
+        // Artificial pre-state: IFF1=1, IFF2=0 (simulates a nested NMI scenario)
+        _emulator.Interupts.IFF1 = true;
+        _emulator.Interupts.IFF2 = false;
+
+        _emulator.Interupts.RaiseNmi();
+        _emulator.Tick();
+
+        _emulator.Interupts.IFF2.ShouldBeTrue();   // took IFF1's value
+        _emulator.Interupts.IFF1.ShouldBeFalse();  // cleared
+    }
+}

--- a/Z80Emu.Tests/Processor/InteruptsTests.cs
+++ b/Z80Emu.Tests/Processor/InteruptsTests.cs
@@ -86,4 +86,37 @@ public class InteruptsTests
         _emulator.CPU.Registers.PC.ShouldBe((word)0x0038);
         _emulator.Interupts.IFF1.ShouldBeFalse();
     }
+
+    [Test]
+    public void Im2_Entry_ReadsVectorFromTable()
+    {
+        _emulator.Interupts.Mode = InterruptMode.Mode2;
+        _emulator.Interupts.IFF1 = true;
+        _emulator.CPU.Registers.I = 0x80;
+        // Vector table at 0x80NN — entry 0x04 contains 0x1234 (little-endian).
+        _emulator.Memory[0x8004] = 0x34;
+        _emulator.Memory[0x8005] = 0x12;
+
+        _emulator.Interupts.RaiseInterrupt(0x04);
+        var op = _emulator.Tick();
+
+        op.Mnemonic.ShouldBe("INT");
+        _emulator.CPU.Registers.PC.ShouldBe((word)0x1234);
+    }
+
+    [Test]
+    public void Im2_Entry_DefaultByteIs0xFF()
+    {
+        _emulator.Interupts.Mode = InterruptMode.Mode2;
+        _emulator.Interupts.IFF1 = true;
+        _emulator.CPU.Registers.I = 0x80;
+        // No data byte supplied — should read from 0x80FF / 0x8100.
+        _emulator.Memory[0x80FF] = 0xCD;
+        _emulator.Memory[0x8100] = 0xAB;
+
+        _emulator.Interupts.RaiseInterrupt();
+        _emulator.Tick();
+
+        _emulator.CPU.Registers.PC.ShouldBe((word)0xABCD);
+    }
 }

--- a/Z80Emu.Tests/Processor/InteruptsTests.cs
+++ b/Z80Emu.Tests/Processor/InteruptsTests.cs
@@ -49,4 +49,41 @@ public class InteruptsTests
         _emulator.Interupts.IFF2.ShouldBeTrue();   // took IFF1's value
         _emulator.Interupts.IFF1.ShouldBeFalse();  // cleared
     }
+
+    [Test]
+    public void Im1_Entry_PushesPC_JumpsTo0x0038_ClearsIffAndLatch()
+    {
+        _emulator.Interupts.Mode = InterruptMode.Mode1;
+        _emulator.Interupts.IFF1 = true;
+        _emulator.Interupts.IFF2 = true;
+        word originalPC = _emulator.CPU.Registers.PC;
+        word originalSP = _emulator.CPU.Registers.SP;
+
+        _emulator.Interupts.RaiseInterrupt();
+        var op = _emulator.Tick();
+
+        op.Mnemonic.ShouldBe("INT");
+        _emulator.CPU.Registers.PC.ShouldBe((word)0x0038);
+        _emulator.CPU.Registers.SP.ShouldBe((word)(originalSP - 2));
+        _emulator.Memory[(word)(originalSP - 2)].ShouldBe(originalPC.Lsb());
+        _emulator.Memory[(word)(originalSP - 1)].ShouldBe(originalPC.Msb());
+        _emulator.Interupts.IFF1.ShouldBeFalse();
+        _emulator.Interupts.IFF2.ShouldBeFalse();
+        _emulator.Interupts.IsRequested.ShouldBeFalse();
+    }
+
+    [Test]
+    public void Im0_Entry_BehavesLikeRst38h()
+    {
+        _emulator.Interupts.Mode = InterruptMode.Mode0;
+        _emulator.Interupts.IFF1 = true;
+        _emulator.Interupts.IFF2 = true;
+
+        _emulator.Interupts.RaiseInterrupt();
+        var op = _emulator.Tick();
+
+        op.Mnemonic.ShouldBe("INT");
+        _emulator.CPU.Registers.PC.ShouldBe((word)0x0038);
+        _emulator.Interupts.IFF1.ShouldBeFalse();
+    }
 }

--- a/Z80Emu.Tests/Processor/InteruptsTests.cs
+++ b/Z80Emu.Tests/Processor/InteruptsTests.cs
@@ -119,4 +119,61 @@ public class InteruptsTests
 
         _emulator.CPU.Registers.PC.ShouldBe((word)0xABCD);
     }
+
+    [Test]
+    public void MaskableInt_NotServiced_When_IFF1_False()
+    {
+        _emulator.Interupts.Mode = InterruptMode.Mode1;
+        _emulator.Interupts.IFF1 = false;
+
+        _emulator.Interupts.RaiseInterrupt();
+        var op = _emulator.Tick();
+
+        op.Mnemonic.ShouldBe("NOP");                          // executed memory, not INT
+        _emulator.Interupts.IsRequested.ShouldBeTrue();       // latch still set
+        _emulator.CPU.Registers.PC.ShouldNotBe((word)0x0038);
+    }
+
+    [Test]
+    public void MaskableInt_OneShot_DoesNotReFire()
+    {
+        _emulator.Interupts.Mode = InterruptMode.Mode1;
+        _emulator.Interupts.IFF1 = true;
+
+        _emulator.Interupts.RaiseInterrupt();
+        _emulator.Tick();   // services the interrupt
+        // Put a NOP at the vector so the next tick has something to fetch.
+        _emulator.Memory[0x0038] = 0x00;
+        var op = _emulator.Tick();
+
+        op.Mnemonic.ShouldBe("NOP");                          // not another INT
+    }
+
+    [Test]
+    public void Nmi_NotGatedBy_IFF1()
+    {
+        _emulator.Interupts.IFF1 = false;
+
+        _emulator.Interupts.RaiseNmi();
+        var op = _emulator.Tick();
+
+        op.Mnemonic.ShouldBe("NMI");
+        _emulator.CPU.Registers.PC.ShouldBe((word)0x0066);
+    }
+
+    [Test]
+    public void Im2_Entry_VectorPointerWrapsAt0xFFFF()
+    {
+        _emulator.Interupts.Mode = InterruptMode.Mode2;
+        _emulator.Interupts.IFF1 = true;
+        _emulator.CPU.Registers.I = 0xFF;
+        // RequestData = 0xFF -> vectorPtr = 0xFFFF; high-byte read should wrap to 0x0000.
+        _emulator.Memory[0xFFFF] = 0x78;
+        _emulator.Memory[0x0000] = 0x56;
+
+        _emulator.Interupts.RaiseInterrupt(0xFF);
+        _emulator.Tick();
+
+        _emulator.CPU.Registers.PC.ShouldBe((word)0x5678);
+    }
 }

--- a/Z80Emu.Tests/Processor/InteruptsTests.cs
+++ b/Z80Emu.Tests/Processor/InteruptsTests.cs
@@ -176,4 +176,66 @@ public class InteruptsTests
 
         _emulator.CPU.Registers.PC.ShouldBe((word)0x5678);
     }
+
+    [Test]
+    public void EiShadow_DefersInterruptByOneInstruction()
+    {
+        _emulator.Interupts.Mode = InterruptMode.Mode1;
+        // Program: EI ; NOP ; NOP
+        _emulator.Memory[0x0100] = 0xFB;  // EI
+        _emulator.Memory[0x0101] = 0x00;  // NOP
+        _emulator.Memory[0x0102] = 0x00;  // NOP
+
+        var op1 = _emulator.Tick();       // executes EI; sets IFF1=IFF2=true, EiPending=true
+        op1.Mnemonic.ShouldBe("EI");
+
+        _emulator.Interupts.RaiseInterrupt();
+
+        var op2 = _emulator.Tick();       // EI shadow active — should run NOP, not INT
+        op2.Mnemonic.ShouldBe("NOP");
+        _emulator.Interupts.IsRequested.ShouldBeTrue();   // still latched
+
+        var op3 = _emulator.Tick();       // shadow expired — should service now
+        op3.Mnemonic.ShouldBe("INT");
+        _emulator.CPU.Registers.PC.ShouldBe((word)0x0038);
+    }
+
+    [Test]
+    public void EiShadow_AlsoDefersNmi()
+    {
+        _emulator.Memory[0x0100] = 0xFB;  // EI
+        _emulator.Memory[0x0101] = 0x00;  // NOP
+
+        _emulator.Tick();                 // EI
+
+        _emulator.Interupts.RaiseNmi();
+
+        var op2 = _emulator.Tick();       // EI shadow defers NMI too
+        op2.Mnemonic.ShouldBe("NOP");
+        _emulator.Interupts.IsNmiRequested.ShouldBeTrue();
+
+        _emulator.Memory[0x0102] = 0x00;
+        var op3 = _emulator.Tick();
+        op3.Mnemonic.ShouldBe("NMI");
+    }
+
+    [Test]
+    public void Retn_RestoresIFF1_FromIFF2_AfterNmi()
+    {
+        // Pre-state: IFF1=IFF2=true (as if EI had run earlier)
+        _emulator.Interupts.IFF1 = true;
+        _emulator.Interupts.IFF2 = true;
+        // Place RETN at the NMI vector so the second tick will execute it.
+        _emulator.Memory[0x0066] = 0xED;
+        _emulator.Memory[0x0067] = 0x45;
+
+        _emulator.Interupts.RaiseNmi();
+        _emulator.Tick();   // NMI entry: IFF2 takes IFF1's value (still true), IFF1 cleared
+        _emulator.Interupts.IFF1.ShouldBeFalse();
+        _emulator.Interupts.IFF2.ShouldBeTrue();
+
+        var op2 = _emulator.Tick();   // executes RETN at 0x0066
+        op2.Mnemonic.ShouldBe("RETN");
+        _emulator.Interupts.IFF1.ShouldBeTrue();   // restored from IFF2
+    }
 }

--- a/Z80Emu.Tests/Processor/Opcodes/ArithmeticOpcodeTests.cs
+++ b/Z80Emu.Tests/Processor/Opcodes/ArithmeticOpcodeTests.cs
@@ -17,7 +17,7 @@ public class ArithmeticOpcodeTests
     {
         _reg = new Registers();
         _mmu = new MMU();
-        _int = new Interupts(_mmu);
+        _int = new Interupts();
         _ports = new Ports();
         _opcodeHandler = new OpcodeHandler(_reg, _mmu, _int, _ports);
         _reg.PC = 0x0100;

--- a/Z80Emu.Tests/Processor/Opcodes/BitOpcodeTests.cs
+++ b/Z80Emu.Tests/Processor/Opcodes/BitOpcodeTests.cs
@@ -18,7 +18,7 @@ public class BitOpcodeTests
         _reg = new Registers();
         _reg.PC = 0x0100;
         _mmu = new MMU();
-        _int = new Interupts(_mmu);
+        _int = new Interupts();
         _ports = new Ports();
         _opcodeHandler = new OpcodeHandler(_reg, _mmu, _int, _ports);
     }

--- a/Z80Emu.Tests/Processor/Opcodes/ControlOpcodeTests.cs
+++ b/Z80Emu.Tests/Processor/Opcodes/ControlOpcodeTests.cs
@@ -900,4 +900,36 @@ public class ControlOpcodeTests
         _reg.PC.ShouldBe(0x0101);
         _reg.SP.ShouldBe(0xFFFC);
     }
+
+    [Test]
+    public void RST_0()
+    {
+        _mmu[0x0100] = 0xC7;
+
+        _opcodeHandler.FetchVerifyAndExecuteInstruction("RST 0");
+
+        _reg.PC.ShouldBe((word)0x0000);
+        _reg.SP.ShouldBe((word)0xFFFC);
+        _mmu[0xFFFC].ShouldBe((byte)0x01);  // PC.Lsb() pushed at lower addr
+        _mmu[0xFFFD].ShouldBe((byte)0x01);  // PC.Msb() pushed at higher addr
+    }
+
+    [TestCase((byte)0xCF, (word)0x0008, "RST 8")]
+    [TestCase((byte)0xD7, (word)0x0010, "RST 16")]
+    [TestCase((byte)0xDF, (word)0x0018, "RST 24")]
+    [TestCase((byte)0xE7, (word)0x0020, "RST 32")]
+    [TestCase((byte)0xEF, (word)0x0028, "RST 40")]
+    [TestCase((byte)0xF7, (word)0x0030, "RST 48")]
+    [TestCase((byte)0xFF, (word)0x0038, "RST 56")]
+    public void RST_NonZero(byte opcode, word vector, string mnemonic)
+    {
+        _mmu[0x0100] = opcode;
+
+        _opcodeHandler.FetchVerifyAndExecuteInstruction(mnemonic);
+
+        _reg.PC.ShouldBe(vector);
+        _reg.SP.ShouldBe((word)0xFFFC);
+        _mmu[0xFFFC].ShouldBe((byte)0x01);
+        _mmu[0xFFFD].ShouldBe((byte)0x01);
+    }
 }

--- a/Z80Emu.Tests/Processor/Opcodes/ControlOpcodeTests.cs
+++ b/Z80Emu.Tests/Processor/Opcodes/ControlOpcodeTests.cs
@@ -972,4 +972,50 @@ public class ControlOpcodeTests
 
         _int.Mode.ShouldBe(InterruptMode.Mode2);
     }
+
+    [Test]
+    public void EI()
+    {
+        _int.IFF1 = false;
+        _int.IFF2 = false;
+        _int.EiPending = false;
+        _mmu[0x0100] = 0xFB;
+
+        _opcodeHandler.FetchVerifyAndExecuteInstruction("EI");
+
+        _int.IFF1.ShouldBeTrue();
+        _int.IFF2.ShouldBeTrue();
+        _int.EiPending.ShouldBeTrue();
+    }
+
+    [Test]
+    public void DI()
+    {
+        _int.IFF1 = true;
+        _int.IFF2 = true;
+        _int.EiPending = true;
+        _mmu[0x0100] = 0xF3;
+
+        _opcodeHandler.FetchVerifyAndExecuteInstruction("DI");
+
+        _int.IFF1.ShouldBeFalse();
+        _int.IFF2.ShouldBeFalse();
+        _int.EiPending.ShouldBeFalse();
+    }
+
+    [Test]
+    public void LD_A_I_FlagPV_ReflectsIFF2_AfterEI()
+    {
+        // EI; LD A,I — FlagPV should be 1 because IFF2 is now true
+        _mmu[0x0100] = 0xFB;        // EI
+        _mmu[0x0101] = 0xED;        // LD A,I
+        _mmu[0x0102] = 0x57;
+        _reg.I = 0x42;
+
+        _opcodeHandler.FetchVerifyAndExecuteInstruction("EI");
+        _opcodeHandler.FetchVerifyAndExecuteInstruction("LD A,I");
+
+        _reg.A.ShouldBe((byte)0x42);
+        _reg.FlagPV.ShouldBeTrue();
+    }
 }

--- a/Z80Emu.Tests/Processor/Opcodes/ControlOpcodeTests.cs
+++ b/Z80Emu.Tests/Processor/Opcodes/ControlOpcodeTests.cs
@@ -904,14 +904,17 @@ public class ControlOpcodeTests
     [Test]
     public void RST_0()
     {
-        _mmu[0x0100] = 0xC7;
+        // Place the opcode at 0x1234 so the pushed return address (0x1235)
+        // has distinct MSB (0x12) and LSB (0x35), proving byte-order correctness.
+        _reg.PC = 0x1234;
+        _mmu[0x1234] = 0xC7;
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction("RST 0");
 
         _reg.PC.ShouldBe((word)0x0000);
         _reg.SP.ShouldBe((word)0xFFFC);
-        _mmu[0xFFFC].ShouldBe((byte)0x01);  // PC.Lsb() pushed at lower addr
-        _mmu[0xFFFD].ShouldBe((byte)0x01);  // PC.Msb() pushed at higher addr
+        _mmu[0xFFFC].ShouldBe((byte)0x35);  // LSB of return address 0x1235 pushed at lower addr
+        _mmu[0xFFFD].ShouldBe((byte)0x12);  // MSB of return address 0x1235 pushed at higher addr
     }
 
     [TestCase((byte)0xCF, (word)0x0008, "RST 8")]
@@ -923,13 +926,16 @@ public class ControlOpcodeTests
     [TestCase((byte)0xFF, (word)0x0038, "RST 56")]
     public void RST_NonZero(byte opcode, word vector, string mnemonic)
     {
-        _mmu[0x0100] = opcode;
+        // Place the opcode at 0x1234 so the pushed return address (0x1235)
+        // has distinct MSB (0x12) and LSB (0x35), proving byte-order correctness.
+        _reg.PC = 0x1234;
+        _mmu[0x1234] = opcode;
 
         _opcodeHandler.FetchVerifyAndExecuteInstruction(mnemonic);
 
         _reg.PC.ShouldBe(vector);
         _reg.SP.ShouldBe((word)0xFFFC);
-        _mmu[0xFFFC].ShouldBe((byte)0x01);
-        _mmu[0xFFFD].ShouldBe((byte)0x01);
+        _mmu[0xFFFC].ShouldBe((byte)0x35);  // LSB of return address 0x1235 pushed at lower addr
+        _mmu[0xFFFD].ShouldBe((byte)0x12);  // MSB of return address 0x1235 pushed at higher addr
     }
 }

--- a/Z80Emu.Tests/Processor/Opcodes/ControlOpcodeTests.cs
+++ b/Z80Emu.Tests/Processor/Opcodes/ControlOpcodeTests.cs
@@ -938,4 +938,38 @@ public class ControlOpcodeTests
         _mmu[0xFFFC].ShouldBe((byte)0x35);  // LSB of return address 0x1235 pushed at lower addr
         _mmu[0xFFFD].ShouldBe((byte)0x12);  // MSB of return address 0x1235 pushed at higher addr
     }
+
+    [Test]
+    public void IM_0()
+    {
+        _int.Mode = InterruptMode.Mode2;  // start in a non-default mode to prove it changes
+        _mmu[0x0100] = 0xED;
+        _mmu[0x0101] = 0x46;
+
+        _opcodeHandler.FetchVerifyAndExecuteInstruction("IM 0");
+
+        _int.Mode.ShouldBe(InterruptMode.Mode0);
+    }
+
+    [Test]
+    public void IM_1()
+    {
+        _mmu[0x0100] = 0xED;
+        _mmu[0x0101] = 0x56;
+
+        _opcodeHandler.FetchVerifyAndExecuteInstruction("IM 1");
+
+        _int.Mode.ShouldBe(InterruptMode.Mode1);
+    }
+
+    [Test]
+    public void IM_2()
+    {
+        _mmu[0x0100] = 0xED;
+        _mmu[0x0101] = 0x5E;
+
+        _opcodeHandler.FetchVerifyAndExecuteInstruction("IM 2");
+
+        _int.Mode.ShouldBe(InterruptMode.Mode2);
+    }
 }

--- a/Z80Emu.Tests/Processor/Opcodes/ControlOpcodeTests.cs
+++ b/Z80Emu.Tests/Processor/Opcodes/ControlOpcodeTests.cs
@@ -17,7 +17,7 @@ public class ControlOpcodeTests
     {
         _reg = new Registers();
         _mmu = new MMU();
-        _int = new Interupts(_mmu);
+        _int = new Interupts();
         _ports = new Ports();
         _opcodeHandler = new OpcodeHandler(_reg, _mmu, _int, _ports);
         _reg.PC = 0x0100;

--- a/Z80Emu.Tests/Processor/Opcodes/ExchangeOpcodes.cs
+++ b/Z80Emu.Tests/Processor/Opcodes/ExchangeOpcodes.cs
@@ -17,7 +17,7 @@ public class ExchangeOpcodes
     {
         _reg = new Registers();
         _mmu = new MMU();
-        _int = new Interupts(_mmu);
+        _int = new Interupts();
         _ports = new Ports();
         _opcodeHandler = new OpcodeHandler(_reg, _mmu, _int, _ports);
         _reg.PC = 0x0100;

--- a/Z80Emu.Tests/Processor/Opcodes/LoadOpcodeTests.cs
+++ b/Z80Emu.Tests/Processor/Opcodes/LoadOpcodeTests.cs
@@ -17,7 +17,7 @@ public class LoadOpcodeTests
     {
         _reg = new Registers();
         _mmu = new MMU();
-        _int = new Interupts(_mmu);
+        _int = new Interupts();
         _ports = new Ports();
         _opcodeHandler = new OpcodeHandler(_reg, _mmu, _int, _ports);
         _reg.PC = 0x0100;

--- a/Z80Emu.Tests/Processor/Opcodes/PortOpcodeTests.cs
+++ b/Z80Emu.Tests/Processor/Opcodes/PortOpcodeTests.cs
@@ -32,7 +32,7 @@ public class PortOpcodeTests
             PC = 0x0100,
         };
         _mmu = new MMU();
-        _int = new Interupts(_mmu);
+        _int = new Interupts();
         _ports = new Ports();
         _ports[0xCC] = 0x69;
         _ports.OnPortChanged += (sender, args) =>

--- a/Z80Emu/Monitor.cs
+++ b/Z80Emu/Monitor.cs
@@ -83,6 +83,13 @@ internal class Monitor
                 case "reset":   // Reset
                     _emulator.Reset();
                     break;
+                case "int":
+                    HandleInterruptCommand(parts);
+                    break;
+                case "nmi":
+                    _emulator.Interupts.RaiseNmi();
+                    AnsiConsole.MarkupLine("[yellow][[NMI latched]][/]");
+                    break;
                 case "h":   // Help
                     ViewHelp();
                     break;
@@ -175,6 +182,30 @@ internal class Monitor
         return IsTopLevelReturn(opcode);
     }
 
+    void HandleInterruptCommand(string[] parts)
+    {
+        byte? data = null;
+        if (parts.Length >= 2)
+        {
+            if (!parts[1].TryParseHexByte(out byte parsed))
+            {
+                AnsiConsole.MarkupLine("[red]Invalid byte (use hex, e.g. 'int 04')[/]");
+                return;
+            }
+            data = parsed;
+        }
+        _emulator.Interupts.RaiseInterrupt(data);
+        string modeLabel = _emulator.Interupts.Mode switch
+        {
+            InterruptMode.Mode0 => "IM0",
+            InterruptMode.Mode1 => "IM1",
+            InterruptMode.Mode2 => "IM2",
+            _ => "?",
+        };
+        string suffix = data.HasValue ? $", byte=0x{data.Value:X2}" : "";
+        AnsiConsole.MarkupLine($"[yellow][[INT latched: mode={modeLabel}{suffix}]][/]");
+    }
+
     bool Run()
     {
         _lastMemAddr = null;
@@ -208,6 +239,8 @@ internal class Monitor
         AnsiConsole.MarkupLine("[blue]d[/][silver]isassemble[/] [yellow][[address]][/]");
         AnsiConsole.MarkupLine("[blue]b[/][silver]reakpoints[/]");
         AnsiConsole.MarkupLine("[blue]reset[/]");
+        AnsiConsole.MarkupLine("[blue]int[/] [yellow][[byte]][/]");
+        AnsiConsole.MarkupLine("[blue]nmi[/]");
         AnsiConsole.MarkupLine("[blue]q[/][silver]uit[/]");
         AnsiConsole.WriteLine();
     }

--- a/Z80Emu/Monitor.cs
+++ b/Z80Emu/Monitor.cs
@@ -3,7 +3,6 @@ using Z80Emu.Core.Processor.Opcodes;
 namespace Z80Emu;
 
 using System;
-using System.Globalization;
 using System.Reflection;
 using Z80Emu.Core.Processor;
 

--- a/Z80Emu/Z80Emu.csproj
+++ b/Z80Emu/Z80Emu.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Closes #21.

## Summary

- Wires the `IM 0/1/2`, `EI`, `DI` opcode bodies and adds maskable INT + NMI servicing to `Emulator.Tick()`. Servicing runs at the start of each tick and returns a synthetic `INT`/`NMI` pseudo-opcode so the Monitor displays interrupt entry as its own line in `step` output. Honors the EI shadow (one-instruction sampling delay) for both INT and NMI; NMI saves `IFF1 → IFF2` per the Z80 reference.
- Adds `int`, `int <hex>`, and `nmi` REPL commands to drive the new interrupt machinery interactively from the Monitor. Documents them in `README.md` and the new `Interrupt model` section of `CLAUDE.md`.
- Fixes a latent pre-existing bug in the 8 `RST` opcodes — the binding `Execute = () => RST(0x00)` discarded the returned `Action` because `RST` was declared as `Action RST(word) => () => { … }`. Refactored to `public void RST(word)`; same fix supplies the push-PC-and-jump primitive that interrupt entry reuses. Added tests for all 8 RST vectors (none existed).

Design rationale and per-mode behavior (including IM 0 hardcoded as `RST 38h`, the EI shadow, latch lifecycle, and IM 2 vector lookup) is captured in `docs/superpowers/specs/2026-04-27-im-interrupt-instructions-design.md`. Implementation plan in `docs/superpowers/plans/2026-04-27-im-interrupt-instructions.md`.

## Test Plan

- [x] `dotnet build` — clean (0 warnings, 0 errors)
- [x] `dotnet test` — 678 / 678 passing, including:
  - 14 new tests in `InteruptsTests.cs` covering NMI entry, IM 0/1/2 entry, IM 2 vectoring (including 0xFFFF wraparound), IFF1 gating, latch one-shot, EI shadow for both INT and NMI, RETN-after-NMI restore.
  - New `EI`/`DI`/`IM 0/1/2` tests in `ControlOpcodeTests.cs` and a regression test for `LD A,I`'s `FlagPV` (previously silently always 0 because nothing wrote IFF2).
  - 8 new RST tests strengthened with `PC=0x1234` so MSB/LSB stack-push order is provable.
- [ ] Manual REPL smoke: `int` followed by `s` (after EI) shows synthetic `INT` line and PC=0x0038; `nmi` followed by `s` shows synthetic `NMI` line and PC=0x0066.

Version bump 0.6.0 → 0.7.0 (minor — new feature, no breaking changes).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added monitor commands `int` and `nmi` for interrupt latching control with optional IM2 vector support.
  * Enhanced interrupt handling with accurate timing of interrupt servicing during CPU ticks.

* **Documentation**
  * Extended documentation with interrupt model details and monitor command reference.

* **Chores**
  * Version bumped to 0.7.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->